### PR TITLE
Add caching for data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ O sistema foi concebido com uma arquitetura de nível empresarial, focada em rob
   - [Configuração do Ambiente](#configuração-do-ambiente)
   - [Executando o Pipeline Completo](#executando-o-pipeline-completo)
 - [Fluxo do Pipeline de Dados e ML](#fluxo-do-pipeline-de-dados-e-ml)
+- [Cache de Dados](#cache-de-dados)
 - [Roadmap e Próximos Passos](#roadmap-e-próximos-passos)
 - [Como Contribuir](#como-contribuir)
 - [Licença](#licença)
@@ -152,6 +153,8 @@ Quando `make docker-run` é executado, o seguinte pipeline é orquestrado dentro
     -   Carrega o *dataset* de *features*.
     -   Treina o modelo campeão (**Isolation Forest**).
     -   Regista parâmetros, métricas e o artefacto do modelo no MLflow.
+## **Cache de Dados**
+O carregamento do dataset é memorizado no diretório `cache/`. Limpe este diretório caso o caminho do ficheiro Parquet seja alterado.
 
 ## **Roadmap e Próximos Passos**
 

--- a/src/models/train_fraud_model.py
+++ b/src/models/train_fraud_model.py
@@ -54,7 +54,10 @@ from joblib import Memory
 warnings.filterwarnings('ignore')
 
 # Configuração de cache para dados
+# A cache é persistente entre execuções. Remova o diretório
+# 'cache/' ou utilize `memory.clear()` se o caminho do dataset mudar.
 cachedir = Path('cache')
+cachedir.mkdir(exist_ok=True)
 memory = Memory(cachedir, verbose=0)
 
 # Schema para validação de config.yaml (permanece o mesmo)
@@ -260,7 +263,13 @@ class ParquetDataRepository(DataRepository):
         self.project_root = project_root
         self.use_dask = use_dask
 
+    @memory.cache
     def get_prepared_data(self) -> Tuple[Union[pd.DataFrame, dd.DataFrame], Union[pd.DataFrame, dd.DataFrame]]:
+        """Carrega o dataset em Parquet e aplica todas as transformações.
+
+        O resultado é memorizado em disco para acelerar execuções futuras.
+        Limpe o diretório ``cache/`` caso o caminho do dataset mude.
+        """
         # A lógica de carregamento e preparação de dados permanece a mesma.
         data_path = self.project_root / self.config['paths']['data']['featured_dataset']
         df = dd.read_parquet(data_path) if self.use_dask else pd.read_parquet(data_path)


### PR DESCRIPTION
## Summary
- cache data loading for ParquetDataRepository
- create cache directory if absent and document how to clear the cache

## Testing
- `make test` *(fails: NameError in unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_688c25db3dd88332aa3f4a1dcbfa63a0