### PR TITLE
Add IP allow list guard to TrustShield API

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -18,12 +18,14 @@ from typing import Any, List, Optional
 import joblib
 import numpy as np
 import pandas as pd
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 # --- CORREÇÃO ESTRUTURAL ---
 # Importa a função de setup diretamente do seu utilitário.
 from src.utils.mlflow_setup import setup_mlflow
+from src.api.security import enforce_ip_whitelist
 
 # Configuração do Logger (mantida da sua versão original)
 logging.basicConfig(
@@ -245,6 +247,18 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+
+@app.middleware("http")
+async def ip_allowlist_middleware(request: Request, call_next):
+    """Block requests from IPs that are not present in the allow list."""
+
+    try:
+        await enforce_ip_whitelist(request)
+    except HTTPException as exc:
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    return await call_next(request)
 
 
 # =============================================================================

--- a/src/api/security.py
+++ b/src/api/security.py
@@ -1,0 +1,197 @@
+"""Security helpers for TrustShield API.
+
+This module centralizes the logic for enforcing an IP allow list.
+It parses the configuration from environment variables and exposes
+helpers that can be reused by the FastAPI application and in tests.
+"""
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from fastapi import HTTPException, Request, status
+
+__all__ = [
+    "IPAccessControl",
+    "build_ip_access_control",
+    "enforce_ip_whitelist",
+    "extract_client_ips",
+    "reset_ip_access_control_cache",
+]
+
+
+logger = logging.getLogger("trustshield.api.security")
+
+# Environment variable names
+_ALLOWED_IPS_ENV = "TRUSTSHIELD_ALLOWED_IPS"
+_DISABLE_ENV = "TRUSTSHIELD_DISABLE_IP_WHITELIST"
+
+# Default set of loopback identifiers that should be trusted when the
+# environment does not provide an explicit allow list.
+_DEFAULT_ALLOWED_IDENTIFIERS = ("127.0.0.1", "::1", "localhost")
+
+# Cache for the parsed configuration so we do not parse strings on every
+# request. The cache is invalidated whenever the underlying environment
+# value changes.
+_cached_signature: Optional[str] = None
+_cached_access_control: Optional["IPAccessControl"] = None
+
+
+@dataclass
+class IPAccessControl:
+    """In-memory representation of an IP allow list.
+
+    The allow list supports individual IP addresses, hostnames and CIDR
+    ranges. Tokens are normalised on creation for efficient lookups.
+    """
+
+    allows_all: bool
+    hosts: set[str]
+    networks: List[ipaddress._BaseNetwork]
+
+    def is_allowed(self, candidate: str) -> bool:
+        """Return ``True`` when *candidate* is part of the allow list."""
+        if self.allows_all:
+            return True
+
+        if not candidate:
+            return False
+
+        value = candidate.strip()
+        if not value:
+            return False
+
+        lowered = value.lower()
+        if lowered in self.hosts:
+            return True
+
+        try:
+            ip_obj = ipaddress.ip_address(value)
+        except ValueError:
+            return lowered in self.hosts
+
+        if str(ip_obj) in self.hosts:
+            return True
+
+        return any(ip_obj in network for network in self.networks)
+
+
+def _normalise_tokens(raw_tokens: Iterable[str]) -> IPAccessControl:
+    allows_all = False
+    hosts: set[str] = set()
+    networks: List[ipaddress._BaseNetwork] = []
+
+    for raw in raw_tokens:
+        token = raw.strip()
+        if not token:
+            continue
+
+        lowered = token.lower()
+        if lowered == "*":
+            allows_all = True
+            continue
+
+        if lowered == "localhost":
+            hosts.update({"localhost", "127.0.0.1", "::1"})
+            continue
+
+        try:
+            network = ipaddress.ip_network(token, strict=False)
+        except ValueError:
+            try:
+                ip_obj = ipaddress.ip_address(token)
+            except ValueError:
+                hosts.add(lowered)
+            else:
+                hosts.add(str(ip_obj))
+        else:
+            networks.append(network)
+
+    return IPAccessControl(allows_all=allows_all, hosts=hosts, networks=networks)
+
+
+def _allowed_tokens_from_env() -> List[str]:
+    raw = os.getenv(_ALLOWED_IPS_ENV, "")
+    if not raw:
+        return list(_DEFAULT_ALLOWED_IDENTIFIERS)
+
+    tokens = [token.strip() for token in raw.split(",")]
+    filtered = [token for token in tokens if token]
+    return filtered or list(_DEFAULT_ALLOWED_IDENTIFIERS)
+
+
+def build_ip_access_control() -> IPAccessControl:
+    """Build (or reuse) the :class:`IPAccessControl` instance."""
+    global _cached_signature, _cached_access_control
+
+    signature = os.getenv(_ALLOWED_IPS_ENV, "")
+    if _cached_access_control is None or signature != _cached_signature:
+        tokens = _allowed_tokens_from_env()
+        _cached_access_control = _normalise_tokens(tokens)
+        _cached_signature = signature
+        logger.debug("IP allow list rebuilt from signature '%s'", signature)
+
+    return _cached_access_control
+
+
+def reset_ip_access_control_cache() -> None:
+    """Clear the cached allow list (mainly used in tests)."""
+    global _cached_signature, _cached_access_control
+    _cached_signature = None
+    _cached_access_control = None
+
+
+def whitelist_disabled() -> bool:
+    flag = os.getenv(_DISABLE_ENV, "")
+    return flag.lower() in {"1", "true", "yes", "on"}
+
+
+def extract_client_ips(request: Request) -> List[str]:
+    """Return the ordered list of client IPs for *request*.
+
+    The first entries correspond to the ``X-Forwarded-For`` header, followed
+    by the actual socket peer address. The special identifier ``testclient``
+    used by Starlette's :class:`~starlette.testclient.TestClient` is mapped to
+    the IPv4 loopback address so that unit tests behave like local requests.
+    """
+    forwarded_for = request.headers.get("x-forwarded-for")
+    candidates: List[str] = []
+
+    if forwarded_for:
+        forwarded_values = [value.strip() for value in forwarded_for.split(",")]
+        candidates.extend(value for value in forwarded_values if value)
+
+    if request.client and request.client.host:
+        host = request.client.host
+        candidates.append(host)
+        if host == "testclient":
+            candidates.append("127.0.0.1")
+
+    return candidates
+
+
+async def enforce_ip_whitelist(request: Request) -> None:
+    """Ensure that the incoming request originates from an allowed IP."""
+    if whitelist_disabled():
+        return
+
+    controller = build_ip_access_control()
+    if controller.allows_all:
+        return
+
+    candidates = extract_client_ips(request)
+    for candidate in candidates:
+        if controller.is_allowed(candidate):
+            return
+
+    logger.warning(
+        "Rejected request from unauthorised client IP(s): %s",
+        ", ".join(candidates) or "<unknown>",
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Client IP address is not allowed to access this resource.",
+    )

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -28,10 +28,17 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime
 from typing import Dict, Any
 
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 import joblib
 import numpy as np
 import pandas as pd
 import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from ipaddress import ip_network
 
 from sklearn.preprocessing import StandardScaler
 from sklearn.ensemble import IsolationForest
@@ -45,6 +52,11 @@ from src.models.train_fraud_model import (
 from src.models.optimization import DataValidator
 
 from src.api.main import app as fastapi_app
+from src.api.security import (
+    IPAccessControl,
+    enforce_ip_whitelist,
+    reset_ip_access_control_cache,
+)
 from enum import Enum
 
 
@@ -240,6 +252,62 @@ class TestUtils:
         # Chama a função e verifica
         setup_mlflow()
         mock_set_tracking_uri.assert_called_once_with("http://test-mlflow:5000")
+
+
+@pytest.mark.security
+class TestIPAllowList:
+    def test_ip_access_control_accepts_loopback_entries(self):
+        control = IPAccessControl(
+            allows_all=False,
+            hosts={"127.0.0.1", "::1", "localhost"},
+            networks=[],
+        )
+
+        assert control.is_allowed("127.0.0.1")
+        assert control.is_allowed("::1")
+        assert control.is_allowed("localhost")
+        assert not control.is_allowed("192.168.10.20")
+
+    def test_ip_access_control_supports_network_ranges(self):
+        control = IPAccessControl(
+            allows_all=False,
+            hosts=set(),
+            networks=[ip_network("192.168.0.0/24")],
+        )
+
+        assert control.is_allowed("192.168.0.10")
+        assert not control.is_allowed("10.0.0.1")
+
+    @pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI não está instalado.")
+    def test_middleware_blocks_disallowed_ip(self, monkeypatch):
+        reset_ip_access_control_cache()
+        monkeypatch.setenv("TRUSTSHIELD_ALLOWED_IPS", "203.0.113.0/24")
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def guard(request: Request, call_next):
+            try:
+                await enforce_ip_whitelist(request)
+            except HTTPException as exc:
+                return JSONResponse(
+                    status_code=exc.status_code, content={"detail": exc.detail}
+                )
+            return await call_next(request)
+
+        @app.get("/ping")
+        def ping():
+            return {"status": "ok"}
+
+        with TestClient(app) as client:
+            allowed = client.get("/ping", headers={"X-Forwarded-For": "203.0.113.5"})
+            assert allowed.status_code == 200
+
+            denied = client.get("/ping", headers={"X-Forwarded-For": "198.51.100.1"})
+            assert denied.status_code == 403
+
+        monkeypatch.delenv("TRUSTSHIELD_ALLOWED_IPS", raising=False)
+        reset_ip_access_control_cache()
 
 
 @pytest.mark.api


### PR DESCRIPTION
## Summary
- add a FastAPI middleware that enforces the configured IP allow list before handling requests
- centralize allow-list parsing/caching logic in a new security helper so localhost and CIDR ranges are resolved consistently
- extend the advanced test suite with security-focused checks and path bootstrap fixes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1c1ceda608324814e4d6ff93d98c0