### PR TITLE
Allow private network addresses in API allow list

### DIFF
--- a/src/api/security.py
+++ b/src/api/security.py
@@ -29,9 +29,22 @@ logger = logging.getLogger("trustshield.api.security")
 _ALLOWED_IPS_ENV = "TRUSTSHIELD_ALLOWED_IPS"
 _DISABLE_ENV = "TRUSTSHIELD_DISABLE_IP_WHITELIST"
 
-# Default set of loopback identifiers that should be trusted when the
-# environment does not provide an explicit allow list.
-_DEFAULT_ALLOWED_IDENTIFIERS = ("127.0.0.1", "::1", "localhost")
+# Default identifiers that should be trusted when the environment does not
+# provide an explicit allow list. Besides loopback addresses we also trust the
+# common private network ranges used by Docker (172.16.0.0/12) and home/office
+# LANs (10.0.0.0/8 and 192.168.0.0/16), as well as the special hostname
+# ``host.docker.internal`` exposed by Docker Desktop. This makes the API usable
+# out of the box in local development environments while still requiring an
+# explicit allow list for public networks.
+_DEFAULT_ALLOWED_IDENTIFIERS = (
+    "127.0.0.1",
+    "::1",
+    "localhost",
+    "host.docker.internal",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+)
 
 # Cache for the parsed configuration so we do not parse strings on every
 # request. The cache is invalidated whenever the underlying environment

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -54,6 +54,7 @@ from src.models.optimization import DataValidator
 from src.api.main import app as fastapi_app
 from src.api.security import (
     IPAccessControl,
+    build_ip_access_control,
     enforce_ip_whitelist,
     reset_ip_access_control_cache,
 )
@@ -277,6 +278,20 @@ class TestIPAllowList:
 
         assert control.is_allowed("192.168.0.10")
         assert not control.is_allowed("10.0.0.1")
+
+    def test_default_allow_list_accepts_private_networks(self, monkeypatch):
+        reset_ip_access_control_cache()
+        monkeypatch.delenv("TRUSTSHIELD_ALLOWED_IPS", raising=False)
+        monkeypatch.delenv("TRUSTSHIELD_DISABLE_IP_WHITELIST", raising=False)
+
+        control = build_ip_access_control()
+
+        assert control.is_allowed("172.18.0.1")
+        assert control.is_allowed("192.168.1.5")
+        assert control.is_allowed("10.0.5.10")
+        assert control.is_allowed("host.docker.internal")
+
+        reset_ip_access_control_cache()
 
     @pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI não está instalado.")
     def test_middleware_blocks_disallowed_ip(self, monkeypatch):


### PR DESCRIPTION
## Summary
- expand the default allow list to cover Docker hostnames and private network CIDR ranges so local health checks succeed
- add a regression test ensuring the default allow list allows private addresses while keeping cache handling intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d29dba1e048324b0c03ffa6f141b03