### PR TITLE
Fix local API whitelist blocking health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ TrustShield/
 2.  **Prepare os dados brutos:**
     Certifique-se de que os ficheiros de dados (`cards_data.csv`, `users_data.csv`, etc.) estão localizados no diretório `data/raw/`.
 
+3.  **Acesso local à API:**
+    A aplicação aplica uma _whitelist_ de IPs por padrão. O `docker-compose` já exporta `TRUSTSHIELD_DISABLE_IP_WHITELIST=true` para desativar esse bloqueio no ambiente local. Caso execute a API fora do Compose, defina essa variável ou configure `TRUSTSHIELD_ALLOWED_IPS` com os IPs autorizados para evitar respostas HTTP 403.
+
 ### **Executando o Pipeline Completo**
 
 O `Makefile` simplifica a execução do projeto com os seguintes comandos:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -130,6 +130,7 @@ services:
       - AWS_ACCESS_KEY_ID_FILE=/run/secrets/minio_root_user
       - AWS_SECRET_ACCESS_KEY_FILE=/run/secrets/minio_root_password
       - PYTHONUNBUFFERED=1
+      - TRUSTSHIELD_DISABLE_IP_WHITELIST=true
     volumes:
       - ../:/app
     secrets:


### PR DESCRIPTION
## Summary
- disable the API IP whitelist inside the docker compose stack so local health checks stop returning HTTP 403
- document how to disable or configure the whitelist when running the API outside docker compose

## Testing
- `make up` *(fails in CI environment: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_68d3570c383c832285ee934f2d1cecdf