### PR TITLE
Improve MLflow resilience across training and utilities

### DIFF
--- a/src/models/optimization.py
+++ b/src/models/optimization.py
@@ -36,9 +36,17 @@ from dataclasses import dataclass, field, asdict
 # O comentário '# noqa: F401' instrui o linter a ignorar o falso positivo de "import não utilizado",
 # pois estas bibliotecas são usadas dinamicamente pelas classes de Estratégia e Observer.
 import joblib  # noqa: F401
-import mlflow  # noqa: F401
+try:  # pragma: no cover - dependência opcional em ambientes de CI
+    import mlflow  # type: ignore
+except ImportError:  # pragma: no cover - fallback seguro
+    mlflow = None  # type: ignore
 import numpy as np  # noqa: F401
-import optuna  # noqa: F401
+try:  # pragma: no cover - optuna é opcional para alguns fluxos
+    import optuna  # type: ignore
+    OPTUNA_AVAILABLE = True
+except ImportError:  # pragma: no cover - fallback seguro
+    optuna = None  # type: ignore
+    OPTUNA_AVAILABLE = False
 import pandas as pd
 import yaml
 from sklearn.ensemble import IsolationForest  # noqa: F401
@@ -354,8 +362,16 @@ class ConsoleLogObserver(OptimizationObserver):
 class MLflowObserver(OptimizationObserver):
     def __init__(self, experiment_name: str, project_root: Path):
         self.experiment_name, self.project_root = experiment_name, project_root
+        self.enabled = mlflow is not None
+        if not self.enabled:
+            logging.getLogger("TrustShield-Optimizer").warning(
+                "MLflow não disponível - Observer desativado."
+            )
 
     def update(self, event: OptimizationEvent, data: Dict[str, Any]):
+        if not self.enabled or mlflow is None:
+            return
+
         if event == OptimizationEvent.OPTIMIZATION_START:
             mlflow.set_experiment(self.experiment_name)
             mlflow.start_run(
@@ -463,6 +479,11 @@ class OptunaOptimizer(BaseOptimizationStrategy, OptimizationStrategy):
     ) -> Dict[str, Any]:
         start_time = time.time()
         self.logger.log(logging.INFO, "Iniciando otimização com Optuna...")
+        if not OPTUNA_AVAILABLE or optuna is None:
+            raise RuntimeError(
+                "Optuna não está disponível neste ambiente. Instale 'optuna' para executar a otimização."
+            )
+
         study = optuna.create_study(
             direction="maximize", sampler=optuna.samplers.TPESampler(seed=42)
         )

--- a/src/models/train_fraud_model.py
+++ b/src/models/train_fraud_model.py
@@ -19,7 +19,8 @@ from pathlib import Path
 from datetime import datetime
 from multiprocessing import cpu_count
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Callable
+from contextlib import nullcontext
 import psutil
 import pickle
 
@@ -36,7 +37,10 @@ from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.model_selection import train_test_split
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
-import mlflow
+try:  # pragma: no cover - import opcional depende do ambiente
+    import mlflow  # type: ignore
+except ImportError:  # pragma: no cover - fallback para ambientes sem MLflow
+    mlflow = None  # type: ignore
 
 # Tentativa de imports otimizados
 try:
@@ -81,6 +85,72 @@ class IntelI3Optimizer:
         self.n_jobs_optimal = 2  # Usar cores físicos, não threads
         self.use_memory_cache = True  # Aproveitar os 20GB de RAM
         self.compression_level = 1  # Compressão leve para I/O rápido
+        self.mlflow_enabled = False
+
+    def _safe_mlflow_call(self, func: Callable, *args, **kwargs) -> bool:
+        """Executa chamadas ao MLflow de forma resiliente.
+
+        Caso o servidor não esteja disponível, marcamos ``mlflow_enabled`` como
+        ``False`` e continuamos a execução sem interromper o treinamento.
+        """
+
+        if not self.mlflow_enabled:
+            return False
+
+        try:
+            func(*args, **kwargs)
+            return True
+        except Exception as exc:  # pragma: no cover - apenas para logs informativos
+            print(
+                "⚠️  Falha ao comunicar com o MLflow ({}). Prosseguindo sem logging.".format(
+                    exc
+                )
+            )
+            self.mlflow_enabled = False
+            return False
+
+    def _configure_mlflow(self, experiment_name: str) -> None:
+        """Tenta configurar a conexão com o MLflow utilizando o utilitário do projeto.
+
+        Se a configuração falhar (por indisponibilidade do servidor ou ausência
+        de infraestrutura), o treinamento continua normalmente apenas registrando
+        os artefatos locais.
+        """
+
+        if self.mlflow_enabled:
+            return
+
+        if mlflow is None:
+            print(
+                "⚠️  MLflow não está instalado. Prosseguindo sem integração com tracking."
+            )
+            self.mlflow_enabled = False
+            return
+
+        try:
+            from src.utils.mlflow_setup import setup_mlflow
+
+            setup_mlflow(experiment=experiment_name, ensure_bucket=False)
+            self.mlflow_enabled = True
+        except Exception as exc:  # pragma: no cover - comportamento depende do ambiente
+            print(
+                "⚠️  Não foi possível configurar o MLflow automaticamente: {}".format(
+                    exc
+                )
+            )
+            if mlflow is None:
+                return
+            try:
+                mlflow.set_tracking_uri("http://localhost:5000")
+                mlflow.set_experiment(experiment_name)
+                self.mlflow_enabled = True
+            except Exception as inner_exc:
+                print(
+                    "⚠️  MLflow indisponível ({}). Execução continuará sem logging externo.".format(
+                        inner_exc
+                    )
+                )
+                self.mlflow_enabled = False
 
     def optimize_data_loading(self, data_path: str) -> pd.DataFrame:
         """
@@ -368,11 +438,16 @@ class IntelI3Optimizer:
         best_config = {"n_estimators": 100, "max_features": 1.0, "contamination": 0.1}
         print(f"\n🏆 Usando configuração de hiperparâmetros padrão: {best_config}")
 
-        # MLflow setup
-        mlflow.set_tracking_uri("http://mlflow:5000")
+        # MLflow setup resiliente
         experiment_name = "TrustShield Fraud Detection"
-        mlflow.set_experiment(experiment_name)
-        print(f"\n📦 MLflow experiment '{experiment_name}' configurado.")
+        self._configure_mlflow(experiment_name)
+        if self.mlflow_enabled:
+            print(f"\n📦 MLflow experiment '{experiment_name}' configurado.")
+        else:
+            print(
+                "\n⚠️  MLflow não configurado. O treinamento continuará e os modelos serão"
+                " armazenados localmente."
+            )
 
         print("\n" + "=" * 60)
         print("📦 RE-TREINANDO 30 MODELOS COM PIPELINES")
@@ -385,7 +460,22 @@ class IntelI3Optimizer:
         total_start = time.time()
 
         for model_idx in range(30):
-            with mlflow.start_run(run_name=f"Pipeline_Model_{model_idx:02d}"):
+            run_context = nullcontext()
+            if self.mlflow_enabled:
+                try:
+                    run_context = mlflow.start_run(
+                        run_name=f"Pipeline_Model_{model_idx:02d}"
+                    )
+                except Exception as exc:  # pragma: no cover - depende do servidor MLflow
+                    print(
+                        "⚠️  Falha ao iniciar run no MLflow ({}). Prosseguindo sem tracking.".format(
+                            exc
+                        )
+                    )
+                    self.mlflow_enabled = False
+                    run_context = nullcontext()
+
+            with run_context:
                 print(f"\n{'=' * 40}\nModelo {model_idx + 1}/30\n{'=' * 40}")
 
                 start_time = time.time()
@@ -427,20 +517,27 @@ class IntelI3Optimizer:
                     f"   ✅ Concluído em {train_time:.2f}s | Anomaly Rate: {anomaly_rate_test:.2%}"
                 )
 
-                mlflow.log_params(config)
-                mlflow.log_metrics(
-                    {"train_time": train_time, "anomaly_rate_test": anomaly_rate_test}
-                )
-                mlflow.set_tag("architecture", "pipeline")
+                if self.mlflow_enabled and mlflow is not None:
+                    self._safe_mlflow_call(mlflow.log_params, config)
+                    self._safe_mlflow_call(
+                        mlflow.log_metrics,
+                        {
+                            "train_time": train_time,
+                            "anomaly_rate_test": anomaly_rate_test,
+                        },
+                    )
+                    self._safe_mlflow_call(mlflow.set_tag, "architecture", "pipeline")
 
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 model_name = f"isolation_forest_pipeline_{model_idx:02d}_{timestamp}"
-                mlflow.sklearn.log_model(
-                    sk_model=pipeline,
-                    artifact_path="model_pipeline",
-                    registered_model_name=model_name,
-                    input_example=input_example,
-                )
+                if self.mlflow_enabled and mlflow is not None:
+                    self._safe_mlflow_call(
+                        mlflow.sklearn.log_model,
+                        sk_model=pipeline,
+                        artifact_path="model_pipeline",
+                        registered_model_name=model_name,
+                        input_example=input_example,
+                    )
 
                 # Salvar pipeline localmente para a API
                 local_model_path = (

--- a/src/models/validation.py
+++ b/src/models/validation.py
@@ -35,7 +35,12 @@ from dataclasses import dataclass, field, asdict
 
 # Imports essenciais para o funcionamento dinâmico do módulo.
 import joblib  # noqa: F401
-import mlflow  # noqa: F401
+try:  # pragma: no cover - dependência opcional
+    import mlflow  # type: ignore
+    MLFLOW_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    mlflow = None  # type: ignore
+    MLFLOW_AVAILABLE = False
 import numpy as np  # noqa: F401
 import pandas as pd  # noqa: F401
 import yaml  # noqa: F401

--- a/src/utils/mlflow_setup.py
+++ b/src/utils/mlflow_setup.py
@@ -1,9 +1,103 @@
 from __future__ import annotations
-import os, json, time, yaml
-from contextlib import contextmanager
+
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
-import mlflow
+from types import ModuleType, SimpleNamespace
+
+import yaml
+
+try:  # pragma: no cover - dependência opcional
+    import boto3  # type: ignore
+except ImportError:  # pragma: no cover
+    boto3 = None  # type: ignore
+
+try:  # pragma: no cover - dependência opcional
+    import mlflow  # type: ignore
+    MLFLOW_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    mlflow = None  # type: ignore
+    MLFLOW_AVAILABLE = False
+
+
+class _NoOpMlflow:
+    """Implementa uma API mínima do MLflow para ambientes sem a dependência."""
+
+    def __init__(self):
+        self._tracking_uri = "noop://mlflow"
+        self.tracking = SimpleNamespace(MlflowClient=lambda *args, **kwargs: None)
+        self.sklearn = SimpleNamespace(log_model=self._noop, autolog=self._noop)
+
+    def _noop(self, *args, **kwargs):  # pragma: no cover - sem efeitos colaterais
+        return None
+
+    def set_tracking_uri(self, uri: str) -> None:
+        self._tracking_uri = uri
+
+    def get_tracking_uri(self) -> str:
+        return self._tracking_uri
+
+    def set_experiment(self, *args, **kwargs) -> None:
+        pass
+
+    def start_run(self, *args, **kwargs):
+        return nullcontext()
+
+    def log_params(self, *args, **kwargs) -> None:
+        pass
+
+    def log_metrics(self, *args, **kwargs) -> None:
+        pass
+
+    def set_tag(self, *args, **kwargs) -> None:
+        pass
+
+    def set_tags(self, *args, **kwargs) -> None:
+        pass
+
+    def end_run(self, *args, **kwargs) -> None:
+        pass
+
+    def log_artifact(self, *args, **kwargs) -> None:
+        pass
+
+    def active_run(self):
+        return None
+
+
+if not MLFLOW_AVAILABLE:
+    _mlflow_impl = _NoOpMlflow()
+
+    def _wrap(name):
+        def _inner(*args, **kwargs):
+            return getattr(_mlflow_impl, name)(*args, **kwargs)
+
+        return _inner
+
+    _mlflow_module = ModuleType("mlflow")
+    for attr_name in [
+        "set_tracking_uri",
+        "get_tracking_uri",
+        "set_experiment",
+        "start_run",
+        "log_params",
+        "log_metrics",
+        "set_tag",
+        "set_tags",
+        "end_run",
+        "log_artifact",
+        "active_run",
+    ]:
+        setattr(_mlflow_module, attr_name, _wrap(attr_name))
+
+    _mlflow_module.tracking = _mlflow_impl.tracking
+    _mlflow_module.sklearn = _mlflow_impl.sklearn
+    sys.modules.setdefault("mlflow", _mlflow_module)
+    mlflow = _mlflow_module  # type: ignore
 
 _DEF_S3_DOCKER = "http://trustshield_minio:9000"
 _DEF_S3_HOST = "http://localhost:9000"
@@ -48,6 +142,11 @@ def setup_mlflow(
     3. Valor de `mlflow.tracking_uri` no `config.yaml`.
     4. Fallback para localhost se nada for encontrado.
     """
+    if not MLFLOW_AVAILABLE:
+        print(
+            "⚠️  MLflow não está instalado. Será utilizado um stub sem efeitos colaterais."
+        )
+
     config = _load_config()
     mlflow_config = config.get("mlflow", {})
 
@@ -84,7 +183,7 @@ def setup_mlflow(
     )
     mlflow.set_experiment(final_experiment_name)
 
-    if ensure_bucket:
+    if ensure_bucket and boto3 is not None:
         _ensure_minio_bucket(bucket_name, final_s3_endpoint)
 
     print(
@@ -118,11 +217,17 @@ def _ensure_minio_bucket(bucket_name: str, endpoint_url: str) -> None:
 
 def enable_sklearn_autolog(log_models: bool = True) -> None:
     try:
-        import mlflow.sklearn  # noqa
+        from mlflow import sklearn as mlflow_sklearn  # type: ignore
 
-        mlflow.sklearn.autolog(log_models=log_models)
+        mlflow_sklearn.autolog(log_models=log_models)
     except Exception:
-        pass
+        if hasattr(mlflow, "sklearn"):
+            try:
+                mlflow.sklearn.autolog(log_models=log_models)  # type: ignore[attr-defined]
+            except Exception:
+                pass
+        else:
+            pass
 
 
 def log_params_flat(


### PR DESCRIPTION
## Summary
- add resilient MLflow configuration and safe logging wrappers to the IntelI3Optimizer training loop so retraining continues when tracking is unavailable
- provide an in-repo MLflow stub and optional imports across utilities, optimization, and validation modules to avoid import errors while keeping observability hooks
- guard Optuna-based optimization to fail fast with a clear message when the dependency is absent

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d4af54068c83248cc11fc441c0441b