### PR TITLE
Ensure Docker services honour updated project root

### DIFF
--- a/config_path.py
+++ b/config_path.py
@@ -1,0 +1,68 @@
+"""Utility helpers to keep the TrustShield project paths aligned.
+
+This module centralises the discovery of the project root directory and ensures
+that it is always available in ``sys.path``.  Historically some scripts relied
+on implicit working directories which caused issues once the repository was
+moved to a different location (e.g. a new ``PyCharmProjects`` folder or inside
+Docker containers).  Importing :mod:`config_path` stabilises that behaviour by
+
+* detecting the absolute project root, honouring the optional
+  ``TRUSTSHIELD_PROJECT_ROOT`` environment variable;
+* exporting the ``PROJECT_ROOT`` and ``SRC_PATH`` constants; and
+* guaranteeing that both the project root and the ``src`` package directory are
+  present in ``sys.path``.
+
+Any module can simply ``import config_path`` to make sure that imports work no
+matter where the repository lives on disk.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+__all__ = ["PROJECT_ROOT", "SRC_PATH", "ensure_on_path", "discover_project_root"]
+
+
+def _candidate_roots() -> Iterable[Path]:
+    """Yield possible project root directories ordered by priority."""
+
+    env_path = os.getenv("TRUSTSHIELD_PROJECT_ROOT")
+    if env_path:
+        yield Path(env_path).expanduser()
+
+    yield Path(__file__).resolve().parent
+    yield Path.cwd()
+
+
+def discover_project_root() -> Path:
+    """Return the directory that contains the project ``src`` package."""
+
+    for candidate in _candidate_roots():
+        candidate = candidate.resolve()
+        if (candidate / "src").is_dir():
+            return candidate
+    # Fallback to the directory of this file if nothing else was detected.
+    return Path(__file__).resolve().parent
+
+
+PROJECT_ROOT = discover_project_root()
+SRC_PATH = PROJECT_ROOT / "src"
+
+
+def ensure_on_path(path: Path) -> None:
+    """Insert ``path`` into ``sys.path`` if it is not already present."""
+
+    resolved = str(path.resolve())
+    if resolved not in sys.path:
+        sys.path.insert(0, resolved)
+
+
+ensure_on_path(PROJECT_ROOT)
+ensure_on_path(SRC_PATH)
+
+# Expose the detected root through an environment variable so that subprocesses
+# inherit the aligned configuration automatically.
+os.environ.setdefault("TRUSTSHIELD_PROJECT_ROOT", str(PROJECT_ROOT))

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,18 @@ if [ -n "$AWS_SECRET_ACCESS_KEY_FILE" ]; then
     export AWS_SECRET_ACCESS_KEY=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
 fi
 
+# Garante que os serviços internos conheçam a raiz do projeto.
+if [ -z "$TRUSTSHIELD_PROJECT_ROOT" ]; then
+    export TRUSTSHIELD_PROJECT_ROOT="/app"
+fi
+
+# Mantém o diretório ``src`` disponível no PYTHONPATH, mesmo quando o
+# repositório é movido para outro caminho no host.
+case ":$PYTHONPATH:" in
+    *:"$TRUSTSHIELD_PROJECT_ROOT/src":*) ;;
+    *) export PYTHONPATH="$TRUSTSHIELD_PROJECT_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" ;;
+esac
+
 # Agora, execute o comando principal que foi passado para o container
 # (por exemplo, 'uvicorn', 'python -m ...', etc.).
 # O `exec "$@"` garante que este script substitua seu próprio processo

--- a/src/models/optimization.py
+++ b/src/models/optimization.py
@@ -195,16 +195,11 @@ class ConfigManager:
             return {}
 
     def _load_from_yaml(self) -> Dict[str, Any]:
-        with open(self.config_path, "r") as config_file:
+        with open(self.config_path, "r", encoding="utf-8") as config_file:
             config = yaml.safe_load(config_file) or {}
         self.logger.log(
             logging.INFO,
             f"Config loaded from YAML: {self.config_path.relative_to(self.project_root)}",
-        config_path = self.project_root / "config" / "config.yaml")
-        with open(config_path, "r") as config_file:
-            config = yaml.safe_load(config_file) or {}
-        self.logger.log(
-            logging.INFO, f"Config loaded from YAML: {config_path.relative_to(self.project_root)}"
         )
         return config
 
@@ -215,29 +210,6 @@ class ConfigManager:
             and isinstance(config.get("hyper_optimization"), dict)
             and config["hyper_optimization"].get("space")
         )
-
-    def _apply_environment_overrides(self, config: Dict[str, Any]):
-        if "hyper_optimization" not in config:
-            config["hyper_optimization"] = {}
-
-        env = os.getenv("ENV", "development").lower()
-        hyper_cfg = config["hyper_optimization"]
-
-        if env == "production":
-            hyper_cfg["n_trials"] = 100
-            hyper_cfg["early_stopping"] = True
-        elif env == "staging":
-            hyper_cfg["n_trials"] = max(int(hyper_cfg.get("n_trials", 50)), 50)
-
-    def _normalize_keys(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        normalized: Dict[str, Any] = {}
-        for key, value in payload.items():
-            normalized_key = key.lower() if isinstance(key, str) else key
-            if isinstance(value, dict):
-                normalized[normalized_key] = self._normalize_keys(value)
-            else:
-                normalized[normalized_key] = value
-        return normalized
 
     def _apply_environment_overrides(self, config: Dict[str, Any]):
         if "hyper_optimization" not in config:
@@ -736,7 +708,7 @@ class OptimizationStrategyFactory:
 class ResilientHyperparameterOptimizer(Subject):
     def __init__(self, data_path: str, config_path: str = "config/config.yaml"):
         super().__init__()
-        self.project_root = Path(__file__).resolve().parents[2]
+        self.project_root = config_path.PROJECT_ROOT
         self.data_path = Path(data_path)
         config_path_obj = Path(config_path)
         if not config_path_obj.is_absolute():


### PR DESCRIPTION
## Summary
- add a shared `config_path` helper that detects the repository root and keeps it on `sys.path`
- export the project root and `src` directory to Docker services via the entrypoint so code runs from any host path
- tidy the optimization config loader and reuse the shared project root discovery when running pipelines

## Testing
- pytest *(fails: Starlette TestClient is incompatible with bundled httpx version)*

------
https://chatgpt.com/codex/tasks/task_e_68d60d204af88322aa22d60e6768d92e