### PR TITLE
Fix dashboard/API integration and reinforce /predict validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,11 @@ logs: ## Segue logs de todos os serviços
 
 .PHONY: api-logs
 api-logs: ## Logs apenas da API
-	$(DC) logs -f $(API_SERVICE)
+        $(DC) logs -f $(API_SERVICE)
+
+.PHONY: logs-api
+logs-api: ## Alias para seguir logs do serviço trustshield-api
+        $(DC) logs -f $(API_SERVICE)
 
 .PHONY: dash-logs
 dash-logs: ## Logs do dashboard

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -162,11 +162,18 @@ services:
     ports:
       - "8501:8501"
     environment:
-      - API_URL=http://trustshield-api:8000
+      - TRUSTSHIELD_API_URL=http://trustshield-api:8000
+      - RUN_IN_DOCKER=true
+    volumes:
+      - ../src:/app/src
+      - ../data:/app/data
+      - ../outputs:/app/outputs
+      - ../config:/app/config
     networks:
       - trustshield-net
     depends_on:
-      - trustshield-api
+      trustshield-api:
+        condition: service_healthy
 
 # --- Volumes Persistentes ---
 volumes:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -18,8 +18,9 @@ import joblib
 import numpy as np
 import pandas as pd
 from fastapi import FastAPI, HTTPException, BackgroundTasks, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # Setup do MLflow (utilitário do seu projeto)
 from src.utils.mlflow_setup import setup_mlflow
@@ -183,10 +184,22 @@ async def load_model_and_setup_mlflow():
             app_state.model_features = components["features"]
             app_state.model_structure = components["structure"]
 
+            feature_list = app_state.model_features or []
+            transformer_name = (
+                type(app_state.data_transformer).__name__
+                if app_state.data_transformer is not None
+                else "nenhum"
+            )
+            preview = ", ".join(feature_list[:10])
+            if len(feature_list) > 10:
+                preview += ", ..."
             logger.info(
-                "Modelo '%s' carregado. Estrutura: %s.",
+                "Modelo '%s' carregado. Estrutura: %s. Transformador: %s. Features (%d): %s",
                 model_file.name,
                 app_state.model_structure,
+                transformer_name,
+                len(feature_list),
+                preview or "não especificado",
             )
         except Exception as e:
             logger.error(f"Erro ao carregar o modelo de {model_file}: {e}", exc_info=True)
@@ -214,6 +227,15 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://trustshield-dashboard:8501"],
+    allow_origin_regex=r"http://(localhost|127\.0\.0\.1)(:\d+)?",
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 @app.middleware("http")
 async def ip_allowlist_middleware(request: Request, call_next):
@@ -229,27 +251,92 @@ async def ip_allowlist_middleware(request: Request, call_next):
 # =============================================================================
 # DTOs (Data Transfer Objects)
 # =============================================================================
-class TransactionInput(BaseModel):
-    """
-    Estrutura dos dados de entrada para uma predição.
-    Contrato de API estrito para uma única transação.
-    """
-    client_id: int = Field(..., example=12345)
-    amount: float = Field(..., example=123.45)
-    current_age: int = Field(..., example=35)
-    per_capita_income: float = Field(..., example=50000.0)
-    yearly_income: float = Field(..., example=100000.0)
-    total_debt: float = Field(..., example=25000.0)
-    date: str = Field(..., example="2024-01-15T14:30:00")
-    use_chip: str = Field(..., example="Swipe Transaction")
-    gender: str = Field(..., example="F")
+class PredictRequest(BaseModel):
+    """Contrato de entrada para o endpoint ``/predict``."""
+
+    amount: float = Field(
+        ..., gt=0, description="Valor da transação em dólares.", example=120.5
+    )
+    gender: str = Field(
+        ..., description="Sexo do titular do cartão (Male/Female).", example="Male"
+    )
+    use_chip: str = Field(
+        ...,
+        description="Modo de utilização do cartão.",
+        example="Swipe Transaction",
+    )
+    credit_score: int = Field(
+        ..., ge=300, le=900, description="Pontuação de crédito do cliente.", example=720
+    )
+    num_credit_cards: int = Field(
+        ..., ge=0, description="Número de cartões ativos do cliente.", example=3
+    )
+    per_capita_income: float = Field(
+        ..., ge=0, description="Rendimento per capita anual.", example=23679
+    )
+    yearly_income: float = Field(
+        ..., ge=0, description="Rendimento anual declarado.", example=48277
+    )
+    total_debt: float = Field(
+        ..., ge=0, description="Dívida total estimada.", example=110153
+    )
 
     class Config:
-        extra = "forbid"  # bloqueia campos extras
+        extra = "forbid"
+
+    @field_validator("gender")
+    @classmethod
+    def normalise_gender(cls, value: str) -> str:
+        mapping = {
+            "male": "Male",
+            "m": "Male",
+            "masculino": "Male",
+            "female": "Female",
+            "f": "Female",
+            "feminino": "Female",
+        }
+        normalised = value.strip().lower()
+        if normalised not in mapping:
+            raise ValueError("gender deve ser 'Male' ou 'Female'.")
+        return mapping[normalised]
+
+    @field_validator("use_chip")
+    @classmethod
+    def normalise_use_chip(cls, value: str) -> str:
+        allowed = {
+            "swipe transaction": "Swipe Transaction",
+            "chip transaction": "Chip Transaction",
+            "online transaction": "Online Transaction",
+            "contactless transaction": "Contactless Transaction",
+        }
+        normalised = value.strip().lower()
+        if normalised not in allowed:
+            raise ValueError(
+                "use_chip deve ser Swipe Transaction, Chip Transaction, Online Transaction ou Contactless Transaction."
+            )
+        return allowed[normalised]
+
+    def to_model_dict(self) -> dict[str, Any]:
+        data = self.model_dump()
+        data.update(
+            {
+                "amount": float(data["amount"]),
+                "per_capita_income": float(data["per_capita_income"]),
+                "yearly_income": float(data["yearly_income"]),
+                "total_debt": float(data["total_debt"]),
+                "credit_score": int(data["credit_score"]),
+                "num_credit_cards": int(data["num_credit_cards"]),
+            }
+        )
+        return data
+
 
 class PredictionOutput(BaseModel):
     """Estrutura da resposta da predição."""
-    is_anomaly: int = Field(..., example=1, description="-1 = anomalia (fraude), 1 = normal.")
+
+    is_anomaly: bool = Field(
+        ..., example=False, description="True indica possível anomalia."
+    )
     score: float = Field(..., example=-0.2345)
     model_version: str
 
@@ -310,43 +397,66 @@ def get_status():
     }
 
 @app.post("/predict", response_model=PredictionOutput, tags=["Prediction"])
-def predict(transaction: TransactionInput):
-    """
-    Predição de anomalia (IsolationForest).
-    - Seleciona somente colunas numéricas para o transformador.
-    - Respeita a ordem de `model_features` quando disponível.
-    """
+def predict(request: PredictRequest):
+    """Executa a inferência com validação explícita e mensagens claras."""
+
     if app_state.model is None:
         raise HTTPException(status_code=503, detail="Modelo não está disponível.")
 
     try:
-        input_df = pd.DataFrame([transaction.model_dump()])
-        model_obj, transformer, model_features = _resolve_runtime_components(app_state)
+        payload = request.to_model_dict()
+    except ValueError as exc:
+        logger.warning("Entrada inválida em /predict: %s", exc)
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-        if model_obj is None:
-            raise ValueError("Objeto de modelo não inicializado corretamente.")
+    model_obj, transformer, model_features = _resolve_runtime_components(app_state)
 
-        # Apenas colunas numéricas para o transformador/estimador
-        numeric_input_df = input_df.select_dtypes(include=np.number)
+    if model_obj is None:
+        logger.error("Objeto de modelo não inicializado corretamente.")
+        raise HTTPException(status_code=503, detail="Modelo não está disponível.")
 
-        if model_features:
-            missing_features = [f for f in model_features if f not in numeric_input_df.columns]
-            if missing_features:
+    input_df = pd.DataFrame([payload])
+
+    expected_columns: List[str] = []
+    if model_features:
+        expected_columns = list(model_features)
+    elif transformer is not None and hasattr(transformer, "feature_names_in_"):
+        expected_columns = list(getattr(transformer, "feature_names_in_"))
+
+    if expected_columns:
+        missing_columns = [col for col in expected_columns if col not in input_df.columns]
+        if missing_columns:
+            message = (
+                "Campos obrigatórios em falta para predição: "
+                + ", ".join(sorted(missing_columns))
+            )
+            logger.warning(message)
+            raise HTTPException(status_code=422, detail=message)
+        input_for_model = input_df.reindex(columns=expected_columns)
+    else:
+        input_for_model = input_df
+
+    try:
+        if transformer is not None:
+            transformed_input = transformer.transform(input_for_model)
+        else:
+            numeric_only = input_for_model.select_dtypes(include=np.number)
+            if numeric_only.empty:
                 raise HTTPException(
                     status_code=422,
-                    detail="Campos numéricos ausentes para predição: " + ", ".join(sorted(set(missing_features))),
+                    detail="Dados insuficientes: forneça campos numéricos para a predição.",
                 )
-            input_df_for_prediction = numeric_input_df[model_features]
-        else:
-            # Sem schema salvo — usa todas numéricas disponíveis
-            input_df_for_prediction = numeric_input_df
+            transformed_input = numeric_only
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Erro ao transformar dados de entrada: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=422,
+            detail="Erro ao transformar dados para predição. Verifique os valores informados.",
+        ) from exc
 
-        if transformer is not None:
-            transformed_input = transformer.transform(input_df_for_prediction)
-        else:
-            transformed_input = input_df_for_prediction
-
-        # Score (se disponível)
+    try:
         score = None
         decision_fn = getattr(model_obj, "decision_function", None)
         if callable(decision_fn):
@@ -356,17 +466,26 @@ def predict(transaction: TransactionInput):
             if callable(score_samples_fn):
                 score = float(score_samples_fn(transformed_input)[0])
 
-        prediction = int(model_obj.predict(transformed_input)[0])
-        return {
-            "is_anomaly": prediction,
-            "score": float(score) if score is not None else 0.0,
-            "model_version": Path(app_state.model_path).name,
-        }
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Erro durante a predição: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Erro interno no servidor: {e}")
+        raw_prediction = model_obj.predict(transformed_input)[0]
+    except Exception as exc:
+        logger.error("Erro durante a predição: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail="Erro interno, consultar logs."
+        ) from exc
+
+    is_anomaly = bool(raw_prediction == -1 or raw_prediction is True)
+    response = {
+        "is_anomaly": is_anomaly,
+        "score": float(score) if score is not None else 0.0,
+        "model_version": Path(app_state.model_path).name,
+    }
+    logger.info(
+        "Predição concluída | anomalia=%s | score=%.4f | modelo=%s",
+        is_anomaly,
+        response["score"],
+        response["model_version"],
+    )
+    return response
 
 @app.post("/reload", tags=["Admin"])
 async def reload_model(background_tasks: BackgroundTasks):

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,4 @@
+"""Utilitários partilhados entre API, dashboard e tarefas de suporte."""
+
+__all__ = ["paths"]
+

--- a/src/common/paths.py
+++ b/src/common/paths.py
@@ -1,0 +1,25 @@
+"""Funções auxiliares para resolução robusta de caminhos no repositório."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+
+@lru_cache(maxsize=1)
+def repo_root() -> Path:
+    """Descobre a raiz do repositório a partir da localização deste módulo."""
+
+    current = Path(__file__).resolve().parent
+    for _ in range(8):
+        if (current / "config" / "config.yaml").exists():
+            return current
+        if current.parent == current:
+            break
+        current = current.parent
+    # Fallback razoável para ambientes de teste ou diretórios rasos
+    return Path(__file__).resolve().parents[3]
+
+
+__all__ = ["repo_root"]
+

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -29,14 +29,20 @@ for _v in [
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
+import json
 import os
+from pathlib import Path
+
 import requests
+import yaml
 import pandas as pd
 import streamlit as st
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit.components.v1 as components
 import pyarrow.dataset as ds
+
+from src.common.paths import repo_root
 
 # -----------------------------------------------------------------------------
 # Configurações básicas
@@ -56,13 +62,51 @@ st.caption(
 # -----------------------------------------------------------------------------
 # Config e limites
 # -----------------------------------------------------------------------------
-# --- CORREÇÃO APLICADA AQUI ---
-# Constrói o caminho absoluto para o arquivo Parquet a partir do local do script
-# para evitar problemas com o diretório de trabalho atual.
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
-API_URL = os.environ.get("API_URL", "http://trustshield-api:8000")
-PARQUET_PATH = os.path.join(PROJECT_ROOT, "data/features/featured_dataset.parquet")
+ROOT = repo_root()
+CONFIG_PATH = ROOT / "config" / "config.yaml"
+
+CONFIG: dict = {}
+try:
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+        CONFIG = yaml.safe_load(fh) or {}
+except FileNotFoundError:
+    st.warning(
+        "Ficheiro de configuração não encontrado; a usar caminhos padrão por defeito."
+    )
+
+PATHS_SECTION = CONFIG.get("paths", {}) if isinstance(CONFIG, dict) else {}
+DATA_PATHS = PATHS_SECTION.get("data", {})
+FEATURED_DATASET_REL = DATA_PATHS.get(
+    "featured_dataset", "data/features/featured_dataset.parquet"
+)
+FEATURED_DATASET_PATH = ROOT / FEATURED_DATASET_REL
+
+OUTPUT_PATHS = PATHS_SECTION.get("outputs", {})
+VALIDATION_PATHS = OUTPUT_PATHS.get("validation", {}) if isinstance(OUTPUT_PATHS, dict) else {}
+DRIFT_REPORT_REL = (
+    VALIDATION_PATHS.get("drift_detection")
+    if isinstance(VALIDATION_PATHS, dict)
+    else None
+)
+if not DRIFT_REPORT_REL:
+    DRIFT_REPORT_REL = "outputs/validation/drift_detection"
+DRIFT_REPORT_DIR = ROOT / DRIFT_REPORT_REL
+
+API_URL = os.getenv("TRUSTSHIELD_API_URL")
+if not API_URL:
+    run_in_docker = os.getenv("RUN_IN_DOCKER", "").lower() in {"1", "true", "yes"}
+    API_URL = "http://trustshield-api:8000" if run_in_docker else "http://localhost:8000"
+
+SAMPLE_PREDICTION_PAYLOAD = {
+    "amount": 120.5,
+    "gender": "Male",
+    "use_chip": "Swipe Transaction",
+    "credit_score": 720,
+    "num_credit_cards": 3,
+    "per_capita_income": 23679,
+    "yearly_income": 48277,
+    "total_debt": 110153,
+}
 
 MAX_FEED_ROWS = 2000  # máximo de linhas no feed em memória
 MAX_MAP_POINTS = 500  # máximo de pontos no mapa
@@ -92,11 +136,58 @@ def get_api_status():
 
 def predict_transaction(transaction_data: dict):
     try:
-        r = requests.post(f"{API_URL}/predict", json=transaction_data, timeout=10)
-        r.raise_for_status()
-        return r.json()
-    except requests.exceptions.RequestException as e:
-        return {"success": False, "error": str(e)}
+        response = requests.post(
+            f"{API_URL}/predict", json=transaction_data, timeout=10
+        )
+    except requests.exceptions.RequestException as exc:
+        return {
+            "success": False,
+            "status_code": None,
+            "error": f"Não foi possível contactar a API: {exc}",
+        }
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {"detail": response.text}
+
+    if response.status_code == 200:
+        is_anomaly_raw = payload.get("is_anomaly")
+        is_anomaly = bool(is_anomaly_raw)
+        if isinstance(is_anomaly_raw, (int, float)):
+            is_anomaly = int(is_anomaly_raw) == -1
+        elif isinstance(is_anomaly_raw, str):
+            is_anomaly = is_anomaly_raw.strip().lower() in {"-1", "true", "anomaly"}
+
+        label = "ANOMALIA" if is_anomaly else "NORMAL"
+        return {
+            "success": True,
+            "status_code": response.status_code,
+            "data": payload,
+            "prediction_label": label,
+            "is_anomaly": is_anomaly,
+            "confidence_score": payload.get("score"),
+            "model_version": payload.get("model_version"),
+        }
+
+    detail = payload.get("detail", "Resposta inesperada da API.")
+    if isinstance(detail, list):
+        formatted = []
+        for item in detail:
+            if isinstance(item, dict):
+                formatted.append(item.get("msg") or item.get("detail") or str(item))
+            else:
+                formatted.append(str(item))
+        detail = "; ".join(formatted)
+    elif isinstance(detail, dict):
+        detail = detail.get("msg") or detail.get("error") or str(detail)
+
+    return {
+        "success": False,
+        "status_code": response.status_code,
+        "error": detail,
+        "detail": payload,
+    }
 
 
 def explain_transaction(transaction_data: dict):
@@ -138,11 +229,22 @@ def validate_model():
 # Dados: leitura paginada via pyarrow.dataset
 # -----------------------------------------------------------------------------
 def fetch_filtered_data_streaming(
-    parquet_path: str, amount_range, income_range, page_num=1, page_size=PAGE_SIZE
+    parquet_path: Path | str,
+    amount_range,
+    income_range,
+    page_num: int = 1,
+    page_size: int = PAGE_SIZE,
 ):
     """Leitura realmente paginada via pyarrow.dataset: filtra no leitor e só traz a página pedida."""
+    parquet_path = Path(parquet_path)
+    if not parquet_path.exists():
+        st.warning(
+            "Dataset de features não encontrado. Gere-o através do pipeline antes de continuar."
+        )
+        return pd.DataFrame(), 0
+
     try:
-        dataset = ds.dataset(parquet_path, format="parquet")
+        dataset = ds.dataset(str(parquet_path), format="parquet")
     except Exception as e:
         st.error(f"Falha ao abrir dataset Parquet: {e}")
         return pd.DataFrame(), 0
@@ -225,7 +327,7 @@ def create_waterfall_plot(explanation: dict):
 # -----------------------------------------------------------------------------
 with st.sidebar:
     st.header("Status da API")
-    st.write(f"Conectando à API em: {API_URL}")  # LINHA DE DEBUG
+    st.caption(f"Endpoint configurado: {API_URL}")
     if st.button("Atualizar Status", use_container_width=True):
         st.session_state.api_status = get_api_status()
 
@@ -241,32 +343,26 @@ with st.sidebar:
         st.caption(api_status.get("error", "API indisponível."))
 
     st.header("Ações")
+    st.write("Utilize a amostra abaixo para validar rapidamente o endpoint /predict.")
+    st.code(
+        json.dumps(SAMPLE_PREDICTION_PAYLOAD, indent=2, ensure_ascii=False),
+        language="json",
+    )
     if st.button("Testar Predição com Amostra", use_container_width=True):
-        sample_data = {
-            "client_id": 12345,
-            "amount": 250.0,
-            "current_age": 40,
-            "per_capita_income": 50000.0,
-            "yearly_income": 75000.0,
-            "total_debt": 15000.0,
-            "date": "2024-01-15T14:30:00",
-            "use_chip": "Chip Transaction",
-            "gender": "M",
-        }
+        sample_data = dict(SAMPLE_PREDICTION_PAYLOAD)
         st.session_state.last_prediction_input = sample_data
         prediction = predict_transaction(sample_data)
         st.session_state.last_prediction_result = prediction
         st.session_state.last_explanation = None
 
-        if (
-            prediction.get("success")
-            and prediction.get("prediction_label") == "ANOMALIA"
-        ):
+        if prediction.get("success") and prediction.get("is_anomaly"):
             new_entry = pd.DataFrame(
                 [
                     {
                         "Timestamp": pd.to_datetime(
-                            prediction.get("timestamp", pd.Timestamp.utcnow())
+                            prediction.get("data", {}).get(
+                                "timestamp", pd.Timestamp.utcnow()
+                            )
                         ),
                         "Label": prediction.get("prediction_label"),
                         "Score": prediction.get("confidence_score"),
@@ -279,7 +375,6 @@ with st.sidebar:
             st.session_state.anomaly_feed = pd.concat(
                 [new_entry, st.session_state.anomaly_feed], ignore_index=True
             )
-            # cap o tamanho do feed
             if len(st.session_state.anomaly_feed) > MAX_FEED_ROWS:
                 st.session_state.anomaly_feed = st.session_state.anomaly_feed.head(
                     MAX_FEED_ROWS
@@ -360,6 +455,9 @@ with tab1:
             c1, c2 = st.columns(2)
             with c1:
                 st.success(f"**Resultado:** {result.get('prediction_label', 'N/A')}")
+                st.caption(
+                    f"Score: {result.get('confidence_score', 'N/A')} | Modelo: {result.get('model_version', 'N/A')}"
+                )
                 if st.button("Explicar Predição (SHAP)"):
                     with st.spinner("Iniciando análise de explicação..."):
                         explanation_job = explain_transaction(
@@ -413,7 +511,23 @@ with tab1:
                 else:
                     st.error(f"Falha ao gerar explicação: {exp.get('error')}")
         else:
-            st.error(result.get("error", "Falha desconhecida na predição."))
+            error_message = result.get("error", "Falha desconhecida na predição.")
+            if result.get("status_code") in {400, 422}:
+                st.warning(
+                    "Entrada inválida: "
+                    + error_message
+                    + " — valide os campos obrigatórios ou utilize 'Testar Predição com Amostra'."
+                )
+            else:
+                st.error(
+                    "Não foi possível concluir a predição: "
+                    + error_message
+                )
+            with st.expander("Payload enviado", expanded=False):
+                st.json(st.session_state.last_prediction_input, expanded=False)
+            st.caption(
+                "Sugestão: na barra lateral clique em 'Testar Predição com Amostra' para um exemplo válido."
+            )
     else:
         st.info("Clique em 'Testar Predição com Amostra' para ver os detalhes.")
 
@@ -425,7 +539,11 @@ with tab2:
 
     st.subheader("Explorador de Dados (paginado)")
     filtered_data, total_records = fetch_filtered_data_streaming(
-        PARQUET_PATH, amount_range, income_range, st.session_state.page_num, PAGE_SIZE
+        FEATURED_DATASET_PATH,
+        amount_range,
+        income_range,
+        st.session_state.page_num,
+        PAGE_SIZE,
     )
 
     if not filtered_data.empty:
@@ -485,20 +603,16 @@ with tab3:
     st.markdown("---")
     st.subheader("Relatórios de Validação Disponíveis")
 
-    report_dir = "outputs/validation/drift_detection"
-    if os.path.exists(report_dir):
-        report_files = [f for f in os.listdir(report_dir) if f.endswith(".html")]
-        if report_files:
-            selected_report = st.selectbox(
-                "Selecione um relatório para visualizar", report_files
-            )
-            if selected_report:
-                with open(
-                    os.path.join(report_dir, selected_report), "r", encoding="utf-8"
-                ) as f:
-                    html_content = f.read()
-                components.html(html_content, height=600, scrolling=True)
-        else:
-            st.info("Nenhum relatório de drift encontrado.")
+    report_dir = DRIFT_REPORT_DIR
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_files = sorted(p.name for p in report_dir.glob("*.html"))
+    if report_files:
+        selected_report = st.selectbox(
+            "Selecione um relatório para visualizar", report_files
+        )
+        if selected_report:
+            with open(report_dir / selected_report, "r", encoding="utf-8") as f:
+                html_content = f.read()
+            components.html(html_content, height=600, scrolling=True)
     else:
-        st.warning(f"Diretório de relatórios não encontrado: {report_dir}")
+        st.info("Sem relatórios gerados ainda.")


### PR DESCRIPTION
## Summary
- resolve the Streamlit dashboard API base URL through TRUSTSHIELD_API_URL/RUN_IN_DOCKER, load data paths from config, and surface a guided sample payload plus friendlier empty-state messaging.
- introduce a shared repo_root helper while updating docker-compose and the Makefile so the dashboard runs with consistent mounts and an explicit logs-api alias.
- tighten FastAPI /predict handling with a dedicated PredictRequest schema, detailed 422 errors, CORS for localhost dashboards, and richer model startup logging.

## Testing
- python -m compileall src/common src/api src/dashboard

------
https://chatgpt.com/codex/tasks/task_e_68d75bc867248324988dfc1fe18a5b90