### PR TITLE
Fix Makefile indentation and add service aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,20 @@ check: ## Valida pré-requisitos locais (docker / compose / arquivos)
 build: check ## Constrói as imagens dos serviços
 	$(DC) build $(BUILD_ARGS)
 
-.PHONY: up
-up: build ## Sobe todos os serviços e aguarda API healthy
-	$(DC) up -d
+.PHONY: services-up
+services-up: build ## Sobe todos os serviços e aguarda API healthy
+	$(DC) up -d --remove-orphans
 	$(MAKE) wait
 
-.PHONY: down
-down: ## Derruba os serviços (mantém volumes)
+.PHONY: up
+up: services-up ## Alias para services-up
+
+.PHONY: services-down
+services-down: ## Derruba os serviços (mantém volumes)
 	$(DC) down --remove-orphans
+
+.PHONY: down
+down: services-down ## Alias para services-down
 
 .PHONY: restart
 restart: ## Reinicia todos os serviços
@@ -129,7 +135,7 @@ api-logs: ## Logs apenas da API
 
 .PHONY: logs-api
 logs-api: ## Alias para seguir logs do serviço trustshield-api
-        $(DC) logs -f $(API_SERVICE)
+	$(DC) logs -f $(API_SERVICE)
 
 .PHONY: dash-logs
 dash-logs: ## Logs do dashboard

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -42,6 +42,7 @@ import plotly.graph_objects as go
 import streamlit.components.v1 as components
 import pyarrow.dataset as ds
 
+import config_path  # noqa: F401  # garante que src esteja no sys.path em execuções locais
 from src.common.paths import repo_root
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix the logs-api recipe indentation so GNU Make recognizes the command block
- split the up/down commands into services-up and services-down targets and expose aliases for convenience
- ensure the Streamlit dashboard preloads config_path so the src package is importable locally and in Docker

## Testing
- not run (Docker is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d85b958bcc8324be7eb7570a07a459