### PR TITLE
Enhance Docker build and harden API authentication

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,35 +1,40 @@
-# Git
+# Global ignores --------------------------------------------------------------
 .git
 .gitignore
-
-# Docker
-Dockerfile
-docker-compose.yml
-
-# Python
-__pycache__/
-*.pyc
+__pycache__
+*.py[cod]
 *.pyo
-*.pyd
-.pytest_cache/
-.venv/
-venv/
-env/
+*.so
+*.dylib
+*.swp
+*.log
+*.tmp
+.env
+.env.*
+*.ipynb_checkpoints
 
-# Dados e Modelos
-data/
-mlruns/
-outputs/
-cache/
-models/
-
-# Notebooks
+# Large artefacts -------------------------------------------------------------
 notebooks/
+outputs/validation/
+**/__pycache__/
+**/.mypy_cache/
+**/.pytest_cache/
+**/.ruff_cache/
+**/.ipynb_checkpoints/
 
-# IDE
+# Local tooling ---------------------------------------------------------------
+.vscode/
 .idea/
-*.iml
+*.DS_Store
 
-# Outros
-.DS_Store
-local_settings.py
+# Test artefacts --------------------------------------------------------------
+htmlcov/
+.coverage
+.mypy_cache/
+pytest.ini
+.pytest_cache/
+
+# Documentation assets -------------------------------------------------------
+*.pdf
+*.pptx
+*.docx

--- a/README.md
+++ b/README.md
@@ -112,7 +112,13 @@ TrustShield/
     Certifique-se de que os ficheiros de dados (`cards_data.csv`, `users_data.csv`, etc.) estão localizados no diretório `data/raw/`.
 
 3.  **Acesso local à API:**
-    A aplicação aplica uma _whitelist_ de IPs por padrão. O `docker-compose` já exporta `TRUSTSHIELD_DISABLE_IP_WHITELIST=true` para desativar esse bloqueio no ambiente local. Caso execute a API fora do Compose, defina essa variável ou configure `TRUSTSHIELD_ALLOWED_IPS` com os IPs autorizados para evitar respostas HTTP 403.
+    A aplicação aplica uma _whitelist_ de IPs por padrão. O `docker-compose` já define `TRUSTSHIELD_ALLOWED_IPS` com a lista de redes privadas comuns (127.0.0.1, 10/8, 172.16/12, 192.168/16). Caso execute a API fora do Compose, ajuste esta variável para incluir os IPs autorizados ou defina `TRUSTSHIELD_DISABLE_IP_WHITELIST=true` para desativar a restrição durante o desenvolvimento.
+
+4.  **Configuração de API Key:**
+    Além da whitelist, os endpoints agora aceitam uma chave de API enviada no cabeçalho `X-API-Key` (ou no parâmetro `api_key`).
+    -   Configure a variável `TRUSTSHIELD_API_KEYS` com uma lista de chaves separadas por vírgula. É possível fornecer valores em texto simples ou no formato `sha256:<hash>`. Alternativamente, utilize `TRUSTSHIELD_API_KEYS_FILE` apontando para um ficheiro seguro.
+    -   O dashboard lê a chave a partir de `TRUSTSHIELD_API_KEY` (ou `TRUSTSHIELD_API_KEY_FILE`).
+    -   Em ambientes de desenvolvimento o `docker-compose` define automaticamente a chave `local-dev-key`. Para produção, gere uma chave forte e actualize ambas as variáveis.
 
 ### **Executando o Pipeline Completo**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,52 +1,70 @@
-# Dockerfile Otimizado (Multi-stage)
-
+# syntax=docker/dockerfile:1.7
 # ==============================================================================
-# Estágio 1: Builder
-# - Instala dependências de build.
-# - Baixa e compila todas as dependências do Python em "wheels".
+# TrustShield API image
+# ------------------------------------------------------------------------------
+# The image is split into two stages: the *builder* compiles wheels for every
+# dependency while the *runtime* stage keeps only the artefacts required to run
+# the API.  This keeps the final image small and removes the need for build
+# tools such as ``gcc`` at runtime.
 # ==============================================================================
-FROM python:3.11-slim-bookworm as builder
 
-# Instala GCC/build-essential para compilar pacotes como numpy, scipy, etc.
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential gcc && rm -rf /var/lib/apt/lists/*
+ARG PYTHON_VERSION=3.11.9
 
-WORKDIR /wheels
+# ------------------------------------------------------------------------------
+# Builder stage — compiles third party dependencies into wheels
+# ------------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
 
-# Copia o arquivo de lock e cria os wheels.
-# O uso de requirements.lock garante builds 100% reprodutíveis.
-COPY requirements.lock .
-RUN python -m pip install --upgrade pip && \
-    python -m pip wheel -r requirements.lock --wheel-dir /wheels
+ENV \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
-# ==============================================================================
-# Estágio 2: Runtime
-# - Imagem final, leve e segura.
-# - Instala os wheels pré-compilados, sem precisar do compilador.
-# ==============================================================================
-FROM python:3.11-slim-bookworm as runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential gcc \
+    && rm -rf /var/lib/apt/lists/*
 
-# Instala apenas as dependências de runtime (curl, git).
-RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
 
-# Cria um usuário não-root para segurança.
-RUN useradd -ms /bin/bash appuser
+COPY requirements.lock ./requirements.lock
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip wheel --wheel-dir /tmp/wheels -r requirements.lock
+
+# ------------------------------------------------------------------------------
+# Runtime stage — installs the pre-built wheels and application source code
+# ------------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
+
+ENV \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/home/appuser/.local/bin:${PATH}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash appuser
 
 WORKDIR /app
 
-# Copia os wheels do estágio de build e instala a partir deles.
-# --no-index e --find-links garantem que só serão usados os pacotes locais.
-COPY --from=builder /wheels /wheels
-RUN python -m pip install --no-index --find-links=/wheels -r /wheels/requirements.lock && rm -rf /wheels
+COPY --from=builder /tmp/wheels /tmp/wheels
+COPY --from=builder /build/requirements.lock ./requirements.lock
 
-# Copia o código da aplicação.
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-index --find-links=/tmp/wheels -r requirements.lock \
+    && rm -rf /tmp/wheels
+
 COPY . /app
 
-# Ajusta permissões.
-RUN chmod +x docker/entrypoint.sh && chown -R appuser:appuser /app
+RUN chmod +x docker/entrypoint.sh \
+    && chown -R appuser:appuser /app
 
-# Troca para o usuário não-root.
 USER appuser
 
-# Define o entrypoint e o comando padrão.
 ENTRYPOINT ["/app/docker/entrypoint.sh"]
 CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/dashboard.Dockerfile
+++ b/docker/dashboard.Dockerfile
@@ -1,9 +1,73 @@
-FROM python:3.11-slim-bookworm
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 NUMBA_NUM_THREADS=1
+# syntax=docker/dockerfile:1.7
+# ==============================================================================
+# TrustShield dashboard image
+# ------------------------------------------------------------------------------
+# Builds Streamlit with the exact same Python version as the API and keeps the
+# runtime lean by installing dependencies from pre-built wheels.
+# ==============================================================================
+
+ARG PYTHON_VERSION=3.11.9
+
+FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
+
+ENV \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+COPY requirements.lock ./requirements.lock
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip wheel --wheel-dir /tmp/wheels -r requirements.lock
+
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
+
+ENV \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    STREAMLIT_SERVER_PORT=8501 \
+    STREAMLIT_BROWSER_GATHER_USAGE_STATS=false \
+    PATH="/home/appuser/.local/bin:${PATH}" \
+    PYTHONPATH="/app:/app/src"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash appuser
+
 WORKDIR /app
-COPY requirements.txt /app/requirements.txt
-RUN python -m pip install --upgrade pip && python -m pip install -r /app/requirements.txt
+
+COPY --from=builder /tmp/wheels /tmp/wheels
+COPY --from=builder /build/requirements.lock ./requirements.lock
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-index --find-links=/tmp/wheels -r requirements.lock \
+    && rm -rf /tmp/wheels
+
 COPY . /app
+
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
 EXPOSE 8501
-ENV STREAMLIT_SERVER_PORT=8501 STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
-CMD ["streamlit","run","src/dashboard/app.py","--server.port=8501","--server.address=0.0.0.0","--server.headless=true","--server.fileWatcherType=none"]
+
+CMD [
+    "streamlit",
+    "run",
+    "src/dashboard/app.py",
+    "--server.port=8501",
+    "--server.address=0.0.0.0",
+    "--server.headless=true",
+    "--server.fileWatcherType=none",
+]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-  # --- Banco de Dados para MLflow e Metadados ---
   postgres:
     image: postgres:13
     container_name: trustshield-postgres
@@ -16,13 +15,12 @@ services:
       - postgres_password
     networks:
       - trustshield-net
-    healthcheck: # Garante que o Postgres está pronto antes que outros serviços tentem se conectar.
+    healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d mlflow"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  # --- Armazenamento de Artefatos (Modelos, Datasets) ---
   minio:
     image: minio/minio:RELEASE.2023-09-07T02-05-02Z
     container_name: trustshield-minio
@@ -41,21 +39,20 @@ services:
     command: server /data --console-address ":9001"
     networks:
       - trustshield-net
-    healthcheck: # Garante que o MinIO está pronto para receber arquivos.
+    healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 5s
 
-  # --- Job para criar o bucket no MinIO ---
   minio-init:
-    image: minio/mc:latest # <-- CORREÇÃO: Usa a tag 'latest' que é válida para a imagem do cliente MinIO.
+    image: minio/mc:latest
     container_name: trustshield-minio-init
     depends_on:
       minio:
-        condition: service_healthy # Espera o MinIO estar saudável.
-    entrypoint: >
+        condition: service_healthy
+    entrypoint: >-
       /bin/sh -c "
       /usr/bin/mc config host add minio http://minio:9000 $$(cat /run/secrets/minio_root_user) $$(cat /run/secrets/minio_root_password);
       /usr/bin/mc mb minio/mlflow;
@@ -68,7 +65,6 @@ services:
     networks:
       - trustshield-net
 
-    # --- Servidor de MLOps para Rastreamento e Versionamento ---
   mlflow:
     build:
       context: ..
@@ -83,8 +79,7 @@ services:
       - AWS_ACCESS_KEY_ID_FILE=/run/secrets/minio_root_user
       - AWS_SECRET_ACCESS_KEY_FILE=/run/secrets/minio_root_password
       - MLFLOW_S3_ENDPOINT_URL=http://minio:9000
-    # <-- CORREÇÃO: Usamos PGPASSWORD para uma conexão mais robusta com o banco de dados.
-    command: >
+    command: >-
       sh -c '
       export PGPASSWORD=$$(cat /run/secrets/postgres_password) &&
       mlflow server
@@ -113,7 +108,6 @@ services:
       retries: 3
       start_period: 20s
 
-  # --- API principal para inferência e treinamento ---
   trustshield-api:
     build:
       context: ..
@@ -122,15 +116,17 @@ services:
     restart: unless-stopped
     ports:
       - "8000:8000"
-    mem_limit: 8g # Aumenta a memória para o serviço mais pesado (treinamento e processamento de dados).
-    mem_reservation: 4g # Reserva 4GB de RAM.
+    mem_limit: 8g
+    mem_reservation: 4g
     environment:
       - MLFLOW_TRACKING_URI=http://mlflow:5000
       - MLFLOW_S3_ENDPOINT_URL=http://minio:9000
       - AWS_ACCESS_KEY_ID_FILE=/run/secrets/minio_root_user
       - AWS_SECRET_ACCESS_KEY_FILE=/run/secrets/minio_root_password
       - PYTHONUNBUFFERED=1
-      - TRUSTSHIELD_DISABLE_IP_WHITELIST=true
+      - TRUSTSHIELD_ALLOWED_IPS=127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+      - TRUSTSHIELD_API_KEYS=local-dev-key
+      - TRUSTSHIELD_PUBLIC_PATHS=/healthz,/readyz,/status,/docs,/redoc,/openapi.json
     volumes:
       - ../:/app
     secrets:
@@ -138,7 +134,7 @@ services:
       - minio_root_password
     networks:
       - trustshield-net
-    depends_on: # Garante que a API só inicie quando suas dependências estiverem 100% prontas.
+    depends_on:
       mlflow:
         condition: service_healthy
       postgres:
@@ -150,9 +146,8 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
-      start_period: 30s # Tempo maior para o primeiro health check para dar tempo para o FastAPI iniciar
+      start_period: 30s
 
-  # --- Dashboard de Monitoramento ---
   trustshield-dashboard:
     build:
       context: ..
@@ -163,6 +158,8 @@ services:
       - "8501:8501"
     environment:
       - TRUSTSHIELD_API_URL=http://trustshield-api:8000
+      - TRUSTSHIELD_API_KEY=local-dev-key
+      - TRUSTSHIELD_API_KEY_HEADER=X-API-Key
       - RUN_IN_DOCKER=true
     volumes:
       - ../src:/app/src
@@ -175,19 +172,16 @@ services:
       trustshield-api:
         condition: service_healthy
 
-# --- Volumes Persistentes ---
 volumes:
   postgres-data:
     name: trustshield_postgres-data
   minio-data:
     name: trustshield_minio-data
 
-# --- Rede para Comunicação entre Serviços ---
 networks:
   trustshield-net:
     name: trustshield_trustshield-net
 
-# --- Segredos para Credenciais ---
 secrets:
   postgres_password:
     file: ../secrets/postgres_password.txt

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,38 +1,38 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# ====================================================================
-# SCRIPT DE ENTRADA INTELIGENTE PARA O TRUSTSHIELD API
-#
-# Função: Resolver segredos do Docker para variáveis de ambiente
-# que a aplicação (boto3/mlflow) espera.
-# ====================================================================
+# ============================================================================
+# Entry point for the TrustShield containers
+# ----------------------------------------------------------------------------
+# 1. Reads credentials provided as Docker secrets (``*_FILE`` variables).
+# 2. Ensures the project root and ``src`` directory are available in
+#    ``PYTHONPATH`` for any subprocess executed by the container.
+# 3. Finally, hands control to the command defined in the Dockerfile or the
+#    ``docker-compose`` service definition.
+# ============================================================================
 
-# Se a variável AWS_ACCESS_KEY_ID_FILE existir, leia o segredo do arquivo
-# e exporte-o para a variável AWS_ACCESS_KEY_ID.
-if [ -n "$AWS_ACCESS_KEY_ID_FILE" ]; then
-    export AWS_ACCESS_KEY_ID=$(cat "$AWS_ACCESS_KEY_ID_FILE")
-fi
+read_secret() {
+    local var_name="$1"
+    local file_var_name="${var_name}_FILE"
+    local file_path="${!file_var_name:-}"
 
-# Faça o mesmo para a Secret Key.
-if [ -n "$AWS_SECRET_ACCESS_KEY_FILE" ]; then
-    export AWS_SECRET_ACCESS_KEY=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
-fi
+    if [[ -n "${file_path}" && -f "${file_path}" ]]; then
+        export "${var_name}"="$(<"${file_path}")"
+    fi
+}
 
-# Garante que os serviços internos conheçam a raiz do projeto.
-if [ -z "$TRUSTSHIELD_PROJECT_ROOT" ]; then
+read_secret "AWS_ACCESS_KEY_ID"
+read_secret "AWS_SECRET_ACCESS_KEY"
+read_secret "TRUSTSHIELD_API_KEYS"
+read_secret "TRUSTSHIELD_ALLOWED_IPS"
+
+if [[ -z "${TRUSTSHIELD_PROJECT_ROOT:-}" ]]; then
     export TRUSTSHIELD_PROJECT_ROOT="/app"
 fi
 
-# Mantém o diretório ``src`` disponível no PYTHONPATH, mesmo quando o
-# repositório é movido para outro caminho no host.
-case ":$PYTHONPATH:" in
-    *:"$TRUSTSHIELD_PROJECT_ROOT/src":*) ;;
-    *) export PYTHONPATH="$TRUSTSHIELD_PROJECT_ROOT/src${PYTHONPATH:+:$PYTHONPATH}" ;;
+case ":${PYTHONPATH:-}:" in
+    *:"${TRUSTSHIELD_PROJECT_ROOT}/src":*) ;;
+    *) export PYTHONPATH="${TRUSTSHIELD_PROJECT_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}" ;;
 esac
 
-# Agora, execute o comando principal que foi passado para o container
-# (por exemplo, 'uvicorn', 'python -m ...', etc.).
-# O `exec "$@"` garante que este script substitua seu próprio processo
-# pelo processo da aplicação, o que é uma prática recomendada.
 exec "$@"

--- a/docker/mlflow.Dockerfile
+++ b/docker/mlflow.Dockerfile
@@ -1,2 +1,10 @@
 FROM ghcr.io/mlflow/mlflow:v3.3.1
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* && pip install prometheus-flask-exporter psycopg2-binary
+
+ENV \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir prometheus-flask-exporter psycopg2-binary

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel, Field, field_validator
 
 # Setup do MLflow (utilitário do seu projeto)
 from src.utils.mlflow_setup import setup_mlflow
-from src.api.security import enforce_ip_whitelist
+from src.api.security import enforce_api_key, enforce_ip_whitelist
 
 # Configuração do Logger
 logging.basicConfig(
@@ -238,11 +238,12 @@ app.add_middleware(
 
 
 @app.middleware("http")
-async def ip_allowlist_middleware(request: Request, call_next):
-    """Block requests from IPs that are not present in the allow list."""
+async def security_middleware(request: Request, call_next):
+    """Apply IP allow list and API key authentication on every request."""
 
     try:
         await enforce_ip_whitelist(request)
+        await enforce_api_key(request)
     except HTTPException as exc:
         return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
@@ -256,6 +257,9 @@ class PredictRequest(BaseModel):
 
     amount: float = Field(
         ..., gt=0, description="Valor da transação em dólares.", example=120.5
+    )
+    current_age: int = Field(
+        ..., ge=0, le=130, description="Idade atual do titular do cartão.", example=35
     )
     gender: str = Field(
         ..., description="Sexo do titular do cartão (Male/Female).", example="Male"
@@ -326,6 +330,7 @@ class PredictRequest(BaseModel):
                 "total_debt": float(data["total_debt"]),
                 "credit_score": int(data["credit_score"]),
                 "num_credit_cards": int(data["num_credit_cards"]),
+                "current_age": int(data["current_age"]),
             }
         )
         return data
@@ -334,8 +339,11 @@ class PredictRequest(BaseModel):
 class PredictionOutput(BaseModel):
     """Estrutura da resposta da predição."""
 
-    is_anomaly: bool = Field(
-        ..., example=False, description="True indica possível anomalia."
+    is_anomaly: int = Field(
+        ..., example=-1, description="-1 indica anomalia; 0 indica normalidade."
+    )
+    is_anomaly_flag: bool = Field(
+        ..., example=True, description="Indicador booleano auxiliar para consumo da UI."
     )
     score: float = Field(..., example=-0.2345)
     model_version: str
@@ -473,15 +481,16 @@ def predict(request: PredictRequest):
             status_code=500, detail="Erro interno, consultar logs."
         ) from exc
 
-    is_anomaly = bool(raw_prediction == -1 or raw_prediction is True)
+    is_anomaly_flag = bool(raw_prediction == -1 or raw_prediction is True)
     response = {
-        "is_anomaly": is_anomaly,
+        "is_anomaly": -1 if is_anomaly_flag else 0,
+        "is_anomaly_flag": is_anomaly_flag,
         "score": float(score) if score is not None else 0.0,
         "model_version": Path(app_state.model_path).name,
     }
     logger.info(
         "Predição concluída | anomalia=%s | score=%.4f | modelo=%s",
-        is_anomaly,
+        is_anomaly_flag,
         response["score"],
         response["model_version"],
     )

--- a/src/api/security.py
+++ b/src/api/security.py
@@ -1,36 +1,49 @@
 """Security helpers for TrustShield API.
 
-This module centralizes the logic for enforcing an IP allow list.
-It parses the configuration from environment variables and exposes
-helpers that can be reused by the FastAPI application and in tests.
+This module centralises the logic for enforcing an IP allow list and API key
+based authentication.  Configuration is sourced from environment variables (or
+Docker secrets exposed via the ``*_FILE`` convention) and cached in-memory to
+avoid recomputing the same values on every request.
 """
 from __future__ import annotations
 
+import hashlib
+import hmac
 import ipaddress
 import logging
 import os
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
 
 from fastapi import HTTPException, Request, status
 
 __all__ = [
+    "APIKeyConfig",
     "IPAccessControl",
+    "build_api_key_config",
     "build_ip_access_control",
+    "enforce_api_key",
     "enforce_ip_whitelist",
     "extract_client_ips",
+    "reset_api_key_cache",
     "reset_ip_access_control_cache",
 ]
 
 
 logger = logging.getLogger("trustshield.api.security")
 
-# Environment variable names
+# Environment variable names -------------------------------------------------
 _ALLOWED_IPS_ENV = "TRUSTSHIELD_ALLOWED_IPS"
-_DISABLE_ENV = "TRUSTSHIELD_DISABLE_IP_WHITELIST"
+_DISABLE_WHITELIST_ENV = "TRUSTSHIELD_DISABLE_IP_WHITELIST"
+_API_KEYS_ENV = "TRUSTSHIELD_API_KEYS"
+_DISABLE_API_KEY_ENV = "TRUSTSHIELD_DISABLE_API_KEY"
+_API_KEY_HEADER_ENV = "TRUSTSHIELD_API_KEY_HEADER"
+_API_KEY_QUERY_ENV = "TRUSTSHIELD_API_KEY_QUERY"
+_PUBLIC_PATHS_ENV = "TRUSTSHIELD_PUBLIC_PATHS"
 
 # Default identifiers that should be trusted when the environment does not
-# provide an explicit allow list. Besides loopback addresses we also trust the
+# provide an explicit allow list.  Besides loopback addresses we also trust the
 # common private network ranges used by Docker (172.16.0.0/12) and home/office
 # LANs (10.0.0.0/8 and 192.168.0.0/16), as well as the special hostname
 # ``host.docker.internal`` exposed by Docker Desktop. This makes the API usable
@@ -46,20 +59,43 @@ _DEFAULT_ALLOWED_IDENTIFIERS = (
     "192.168.0.0/16",
 )
 
+_DEFAULT_PUBLIC_PATHS = (
+    "/healthz",
+    "/readyz",
+    "/status",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+)
+
 # Cache for the parsed configuration so we do not parse strings on every
-# request. The cache is invalidated whenever the underlying environment
-# value changes.
-_cached_signature: Optional[str] = None
+# request. The cache is invalidated whenever the underlying environment value
+# changes.
+_cached_ip_signature: Optional[str] = None
 _cached_access_control: Optional["IPAccessControl"] = None
+
+_cached_api_key_signature: Optional[str] = None
+_cached_api_key_config: Optional["APIKeyConfig"] = None
+_logged_empty_api_keys = False
+
+
+def _read_env_or_file(name: str) -> str:
+    """Return the value of ``name`` honouring the ``*_FILE`` convention."""
+
+    file_name = f"{name}_FILE"
+    file_path = os.getenv(file_name)
+    if file_path:
+        try:
+            return Path(file_path).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            logger.error("Unable to read secret file for %s: %s", name, exc)
+
+    return os.getenv(name, "").strip()
 
 
 @dataclass
 class IPAccessControl:
-    """In-memory representation of an IP allow list.
-
-    The allow list supports individual IP addresses, hostnames and CIDR
-    ranges. Tokens are normalised on creation for efficient lookups.
-    """
+    """In-memory representation of an IP allow list."""
 
     allows_all: bool
     hosts: set[str]
@@ -67,6 +103,7 @@ class IPAccessControl:
 
     def is_allowed(self, candidate: str) -> bool:
         """Return ``True`` when *candidate* is part of the allow list."""
+
         if self.allows_all:
             return True
 
@@ -90,6 +127,16 @@ class IPAccessControl:
             return True
 
         return any(ip_obj in network for network in self.networks)
+
+
+@dataclass
+class APIKeyConfig:
+    """Configuration required to enforce API key authentication."""
+
+    hashed_keys: set[str]
+    header_name: str
+    query_param: str
+    public_paths: Sequence[str]
 
 
 def _normalise_tokens(raw_tokens: Iterable[str]) -> IPAccessControl:
@@ -127,7 +174,7 @@ def _normalise_tokens(raw_tokens: Iterable[str]) -> IPAccessControl:
 
 
 def _allowed_tokens_from_env() -> List[str]:
-    raw = os.getenv(_ALLOWED_IPS_ENV, "")
+    raw = _read_env_or_file(_ALLOWED_IPS_ENV)
     if not raw:
         return list(_DEFAULT_ALLOWED_IDENTIFIERS)
 
@@ -138,13 +185,14 @@ def _allowed_tokens_from_env() -> List[str]:
 
 def build_ip_access_control() -> IPAccessControl:
     """Build (or reuse) the :class:`IPAccessControl` instance."""
-    global _cached_signature, _cached_access_control
 
-    signature = os.getenv(_ALLOWED_IPS_ENV, "")
-    if _cached_access_control is None or signature != _cached_signature:
+    global _cached_ip_signature, _cached_access_control
+
+    signature = _read_env_or_file(_ALLOWED_IPS_ENV)
+    if _cached_access_control is None or signature != _cached_ip_signature:
         tokens = _allowed_tokens_from_env()
         _cached_access_control = _normalise_tokens(tokens)
-        _cached_signature = signature
+        _cached_ip_signature = signature
         logger.debug("IP allow list rebuilt from signature '%s'", signature)
 
     return _cached_access_control
@@ -152,24 +200,20 @@ def build_ip_access_control() -> IPAccessControl:
 
 def reset_ip_access_control_cache() -> None:
     """Clear the cached allow list (mainly used in tests)."""
-    global _cached_signature, _cached_access_control
-    _cached_signature = None
+
+    global _cached_ip_signature, _cached_access_control
+    _cached_ip_signature = None
     _cached_access_control = None
 
 
 def whitelist_disabled() -> bool:
-    flag = os.getenv(_DISABLE_ENV, "")
+    flag = os.getenv(_DISABLE_WHITELIST_ENV, "")
     return flag.lower() in {"1", "true", "yes", "on"}
 
 
 def extract_client_ips(request: Request) -> List[str]:
-    """Return the ordered list of client IPs for *request*.
+    """Return the ordered list of client IPs for *request*."""
 
-    The first entries correspond to the ``X-Forwarded-For`` header, followed
-    by the actual socket peer address. The special identifier ``testclient``
-    used by Starlette's :class:`~starlette.testclient.TestClient` is mapped to
-    the IPv4 loopback address so that unit tests behave like local requests.
-    """
     forwarded_for = request.headers.get("x-forwarded-for")
     candidates: List[str] = []
 
@@ -188,6 +232,7 @@ def extract_client_ips(request: Request) -> List[str]:
 
 async def enforce_ip_whitelist(request: Request) -> None:
     """Ensure that the incoming request originates from an allowed IP."""
+
     if whitelist_disabled():
         return
 
@@ -207,4 +252,133 @@ async def enforce_ip_whitelist(request: Request) -> None:
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail="Client IP address is not allowed to access this resource.",
+    )
+
+
+def _hash_api_key(value: str) -> str:
+    digest = hashlib.sha256()
+    digest.update(value.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _parse_api_keys(raw_tokens: Iterable[str]) -> set[str]:
+    hashed: set[str] = set()
+    for raw in raw_tokens:
+        token = raw.strip()
+        if not token:
+            continue
+        if token.lower().startswith("sha256:"):
+            hashed.add(token.split(":", 1)[1].strip())
+        else:
+            hashed.add(_hash_api_key(token))
+    return hashed
+
+
+def _public_paths_from_env() -> Sequence[str]:
+    raw = os.getenv(_PUBLIC_PATHS_ENV, "")
+    if not raw:
+        return _DEFAULT_PUBLIC_PATHS
+    paths = [item.strip() for item in raw.split(",") if item.strip()]
+    return tuple(paths) or _DEFAULT_PUBLIC_PATHS
+
+
+def build_api_key_config() -> APIKeyConfig:
+    """Return the cached API key configuration."""
+
+    global _cached_api_key_signature, _cached_api_key_config, _logged_empty_api_keys
+
+    raw_keys = _read_env_or_file(_API_KEYS_ENV)
+    header_name = os.getenv(_API_KEY_HEADER_ENV, "X-API-Key")
+    query_param = os.getenv(_API_KEY_QUERY_ENV, "api_key")
+    public_paths = _public_paths_from_env()
+
+    hashed_keys = _parse_api_keys(raw_keys.split(","))
+    signature_components = [
+        ",".join(sorted(hashed_keys)),
+        header_name.lower(),
+        query_param.lower(),
+        ",".join(public_paths),
+    ]
+    signature = "|".join(signature_components)
+
+    if _cached_api_key_config is None or signature != _cached_api_key_signature:
+        _cached_api_key_config = APIKeyConfig(
+            hashed_keys=hashed_keys,
+            header_name=header_name,
+            query_param=query_param,
+            public_paths=public_paths,
+        )
+        _cached_api_key_signature = signature
+        _logged_empty_api_keys = False
+        logger.debug("API key configuration refreshed (header=%s, query=%s)", header_name, query_param)
+
+    if not _cached_api_key_config.hashed_keys and not _logged_empty_api_keys:
+        logger.warning(
+            "API key authentication is enabled but no keys were provided. "
+            "Requests will be accepted."
+        )
+        _logged_empty_api_keys = True
+
+    return _cached_api_key_config
+
+
+def reset_api_key_cache() -> None:
+    """Clear the cached API key configuration (used in tests)."""
+
+    global _cached_api_key_signature, _cached_api_key_config, _logged_empty_api_keys
+    _cached_api_key_signature = None
+    _cached_api_key_config = None
+    _logged_empty_api_keys = False
+
+
+def api_key_disabled() -> bool:
+    flag = os.getenv(_DISABLE_API_KEY_ENV, "")
+    return flag.lower() in {"1", "true", "yes", "on"}
+
+
+def _is_public_path(path: str, public_paths: Sequence[str]) -> bool:
+    for candidate in public_paths:
+        if not candidate:
+            continue
+        if candidate.endswith("*"):
+            prefix = candidate[:-1]
+            if path.startswith(prefix):
+                return True
+        elif path == candidate:
+            return True
+    return False
+
+
+async def enforce_api_key(request: Request) -> None:
+    """Validate the API key provided via header or query parameter."""
+
+    if api_key_disabled():
+        return
+
+    config = build_api_key_config()
+    if not config.hashed_keys:
+        return
+
+    if _is_public_path(request.url.path, config.public_paths):
+        return
+
+    header_value = request.headers.get(config.header_name)
+    query_value = request.query_params.get(config.query_param)
+    candidate = header_value or query_value
+
+    if not candidate:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key. Provide it via header or query parameter.",
+        )
+
+    hashed_candidate = _hash_api_key(candidate)
+    for stored in config.hashed_keys:
+        if hmac.compare_digest(stored, hashed_candidate):
+            return
+
+    logger.warning("Rejected request with invalid API key from %s", request.client)
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Invalid API key provided.",
     )

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -32,6 +32,7 @@ for _v in [
 import json
 import os
 from pathlib import Path
+import logging
 
 import requests
 import yaml
@@ -93,13 +94,38 @@ if not DRIFT_REPORT_REL:
     DRIFT_REPORT_REL = "outputs/validation/drift_detection"
 DRIFT_REPORT_DIR = ROOT / DRIFT_REPORT_REL
 
+logger = logging.getLogger(__name__)
+
+
+def _load_api_key() -> str | None:
+    value = os.getenv("TRUSTSHIELD_API_KEY", "").strip()
+    if value:
+        return value
+
+    file_path = os.getenv("TRUSTSHIELD_API_KEY_FILE")
+    if not file_path:
+        return None
+
+    try:
+        return Path(file_path).read_text(encoding="utf-8").strip() or None
+    except OSError as exc:
+        logger.warning("Não foi possível ler o ficheiro do API key (%s): %s", file_path, exc)
+        return None
+
+
 API_URL = os.getenv("TRUSTSHIELD_API_URL")
 if not API_URL:
     run_in_docker = os.getenv("RUN_IN_DOCKER", "").lower() in {"1", "true", "yes"}
     API_URL = "http://trustshield-api:8000" if run_in_docker else "http://localhost:8000"
 
+API_KEY_HEADER = os.getenv("TRUSTSHIELD_API_KEY_HEADER", "X-API-Key")
+API_KEY_VALUE = _load_api_key()
+API_HEADERS = {API_KEY_HEADER: API_KEY_VALUE} if API_KEY_VALUE else {}
+REQUEST_HEADERS = API_HEADERS or None
+
 SAMPLE_PREDICTION_PAYLOAD = {
     "amount": 120.5,
+    "current_age": 37,
     "gender": "Male",
     "use_chip": "Swipe Transaction",
     "credit_score": 720,
@@ -128,7 +154,7 @@ if "page_num" not in st.session_state:
 # -----------------------------------------------------------------------------
 def get_api_status():
     try:
-        r = requests.get(f"{API_URL}/status", timeout=5)
+        r = requests.get(f"{API_URL}/status", timeout=5, headers=REQUEST_HEADERS)
         r.raise_for_status()
         return r.json()
     except requests.exceptions.RequestException as e:
@@ -138,7 +164,10 @@ def get_api_status():
 def predict_transaction(transaction_data: dict):
     try:
         response = requests.post(
-            f"{API_URL}/predict", json=transaction_data, timeout=10
+            f"{API_URL}/predict",
+            json=transaction_data,
+            timeout=10,
+            headers=REQUEST_HEADERS,
         )
     except requests.exceptions.RequestException as exc:
         return {
@@ -193,7 +222,12 @@ def predict_transaction(transaction_data: dict):
 
 def explain_transaction(transaction_data: dict):
     try:
-        r = requests.post(f"{API_URL}/explain", json=transaction_data, timeout=10)
+        r = requests.post(
+            f"{API_URL}/explain",
+            json=transaction_data,
+            timeout=10,
+            headers=REQUEST_HEADERS,
+        )
         if r.status_code == 202:
             return {"success": True, "explanation": r.json()}
         r.raise_for_status()
@@ -204,7 +238,11 @@ def explain_transaction(transaction_data: dict):
 
 def get_explanation_result(job_id: str):
     try:
-        r = requests.get(f"{API_URL}/explanation-result/{job_id}", timeout=5)
+        r = requests.get(
+            f"{API_URL}/explanation-result/{job_id}",
+            timeout=5,
+            headers=REQUEST_HEADERS,
+        )
         if r.status_code == 202:
             return {"success": False, "status_code": 202, "error": "Result not ready"}
         r.raise_for_status()
@@ -219,7 +257,11 @@ def get_explanation_result(job_id: str):
 
 def validate_model():
     try:
-        r = requests.post(f"{API_URL}/validate", timeout=10)
+        r = requests.post(
+            f"{API_URL}/validate",
+            timeout=10,
+            headers=REQUEST_HEADERS,
+        )
         r.raise_for_status()
         return {"success": True, "data": r.json()}
     except requests.exceptions.RequestException as e:

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -56,6 +56,7 @@ from src.api.security import (
     IPAccessControl,
     build_ip_access_control,
     enforce_ip_whitelist,
+    reset_api_key_cache,
     reset_ip_access_control_cache,
 )
 from enum import Enum
@@ -332,8 +333,18 @@ class TestApiFunctionality:
     @pytest.fixture(scope="class")
     def client(self):
         """Fixture para criar um TestClient da API para a classe de testes."""
-        with TestClient(fastapi_app) as c:
-            yield c
+        previous_flag = os.getenv("TRUSTSHIELD_DISABLE_API_KEY")
+        os.environ["TRUSTSHIELD_DISABLE_API_KEY"] = "true"
+        reset_api_key_cache()
+        try:
+            with TestClient(fastapi_app) as c:
+                yield c
+        finally:
+            if previous_flag is None:
+                os.environ.pop("TRUSTSHIELD_DISABLE_API_KEY", None)
+            else:
+                os.environ["TRUSTSHIELD_DISABLE_API_KEY"] = previous_flag
+            reset_api_key_cache()
 
     def test_health_endpoint(self, client):
         response = client.get("/healthz")
@@ -377,13 +388,13 @@ class TestApiFunctionality:
         # The Pydantic model is now stricter.
         # We need to send a payload that is valid for both.
         valid_anomalous_payload = {
-            "client_id": 67890,
             "amount": 9500.0,
             "current_age": 68,
+            "credit_score": 450,
+            "num_credit_cards": 2,
             "per_capita_income": 30000,
             "yearly_income": 40000,
             "total_debt": 80000,
-            "date": "2024-01-20T03:00:00",
             "use_chip": "Online Transaction",
             "gender": "M",
         }

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,111 @@
+import asyncio
+import hashlib
+import os
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from src.api import security
+
+
+async def _receive() -> dict:
+    return {"type": "http.request"}
+
+
+def _build_request(path: str = "/predict", headers: dict | None = None, query: str = "") -> Request:
+    raw_headers = []
+    for key, value in (headers or {}).items():
+        raw_headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": raw_headers,
+        "query_string": query.encode("latin-1"),
+        "client": ("127.0.0.1", 12345),
+    }
+    return Request(scope, _receive)
+
+
+@pytest.fixture(autouse=True)
+def _reset_environment(monkeypatch):
+    monkeypatch.delenv("TRUSTSHIELD_API_KEYS", raising=False)
+    monkeypatch.delenv("TRUSTSHIELD_API_KEYS_FILE", raising=False)
+    monkeypatch.delenv("TRUSTSHIELD_DISABLE_API_KEY", raising=False)
+    monkeypatch.delenv("TRUSTSHIELD_API_KEY_HEADER", raising=False)
+    monkeypatch.delenv("TRUSTSHIELD_API_KEY_QUERY", raising=False)
+    monkeypatch.delenv("TRUSTSHIELD_PUBLIC_PATHS", raising=False)
+    security.reset_api_key_cache()
+    yield
+    security.reset_api_key_cache()
+
+
+def test_enforce_api_key_accepts_valid_header(monkeypatch):
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS", "local-key")
+    request = _build_request(headers={"X-API-Key": "local-key"})
+
+    asyncio.run(security.enforce_api_key(request))
+
+
+def test_enforce_api_key_accepts_public_paths(monkeypatch):
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS", "another-key")
+    request = _build_request(path="/healthz")
+
+    asyncio.run(security.enforce_api_key(request))
+
+
+def test_enforce_api_key_supports_query_parameter(monkeypatch):
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS", "dev")
+    request = _build_request(query="api_key=dev")
+
+    asyncio.run(security.enforce_api_key(request))
+
+
+def test_enforce_api_key_rejects_invalid(monkeypatch):
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS", "secret")
+    request = _build_request(headers={"X-API-Key": "wrong"})
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(security.enforce_api_key(request))
+
+    assert excinfo.value.status_code == 403
+
+
+def test_enforce_api_key_raises_when_missing(monkeypatch):
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS", "missing-test")
+    request = _build_request()
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(security.enforce_api_key(request))
+
+    assert excinfo.value.status_code == 401
+
+
+def test_enforce_api_key_respects_disable_flag(monkeypatch):
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS", "disabled")
+    monkeypatch.setenv("TRUSTSHIELD_DISABLE_API_KEY", "true")
+    request = _build_request()
+
+    asyncio.run(security.enforce_api_key(request))
+
+
+def test_enforce_api_key_accepts_hashed_tokens(monkeypatch):
+    hashed = hashlib.sha256(b"super-secret").hexdigest()
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS", f"sha256:{hashed}")
+
+    request = _build_request(headers={"X-API-Key": "super-secret"})
+
+    asyncio.run(security.enforce_api_key(request))
+
+
+def test_api_key_loaded_from_file(monkeypatch, tmp_path):
+    secret_file = tmp_path / "api_key.txt"
+    secret_file.write_text("file-secret", encoding="utf-8")
+    monkeypatch.delenv("TRUSTSHIELD_API_KEYS", raising=False)
+    monkeypatch.setenv("TRUSTSHIELD_API_KEYS_FILE", os.fspath(secret_file))
+
+    request = _build_request(headers={"X-API-Key": "file-secret"})
+
+    asyncio.run(security.enforce_api_key(request))


### PR DESCRIPTION
## Summary
- convert the API and dashboard Dockerfiles into reproducible multi-stage builds, add a project-wide .dockerignore, and tighten the compose/entrypoint configuration
- introduce API key authentication alongside the IP whitelist, update the FastAPI schema/response to surface raw anomaly signals, and exercise the new behaviour with dedicated tests
- teach the Streamlit dashboard and documentation about the new security controls so local and container executions keep working out of the box

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86ae29b388324b2b5f8f93a8bc8d2