### PR TITLE
Fix Docker CMD definitions for API and dashboard builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,5 +67,7 @@ RUN chmod +x docker/entrypoint.sh \
 USER appuser
 
 ENTRYPOINT ["/app/docker/entrypoint.sh"]
+# Mantemos um único comando default para evitar conflitos durante o build.
+# Para habilitar ``--reload`` em desenvolvimento, sobrescreva o comando via
+# docker compose (``command:``) ou ``docker run`` conforme necessário.
 CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
-CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker/dashboard.Dockerfile
+++ b/docker/dashboard.Dockerfile
@@ -62,13 +62,9 @@ USER appuser
 
 EXPOSE 8501
 
-CMD ["streamlit", \
-     "run", \
-     "src/dashboard/app.py", \
-     "--server.port=8501", \
-     "--server.address=0.0.0.0", \
-     "--server.headless=true", \
-     "--server.fileWatcherType=none"]
+# Use uma única instrução CMD no formato JSON. A variante abaixo é compatível
+# com o Compose e evita erros de parsing no Dockerfile (as instruções
+# duplicadas com vírgula terminal quebravam o build).
 CMD [
     "streamlit",
     "run",
@@ -76,5 +72,5 @@ CMD [
     "--server.port=8501",
     "--server.address=0.0.0.0",
     "--server.headless=true",
-    "--server.fileWatcherType=none",
+    "--server.fileWatcherType=none"
 ]


### PR DESCRIPTION
## Summary
- remove duplicate CMD instructions from the API and dashboard Dockerfiles
- clarify how to enable reload mode outside of the default Docker image
- ensure Streamlit container command uses a single, valid JSON-formatted CMD

## Testing
- not run (Docker is unavailable in the CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68d88094e0b08324a8cd05910008320f